### PR TITLE
Verify graders reject a wrong answer, not just accept a right one

### DIFF
--- a/skills/skill-eval-loop/references/eval-suite-schema.md
+++ b/skills/skill-eval-loop/references/eval-suite-schema.md
@@ -55,6 +55,13 @@ report the same verdict for both conditions, so the paired comparison says
 nothing. A counter-reference is part of the case, so adding one changes the case
 hash and the provenance manifest needs re-registering.
 
+`counter_reference` must include a string `response` (empty objects are
+rejected). It is only valid when the case has at least one response-sensitive
+grader (`response_contains`, `response_not_contains`, `response_regex`,
+`markdown_table_column_regex`, or `model_rubric`). The canary grades the wrong
+response on the gold `reference` workspace, so `file_exists` / `json_exact`
+alone cannot discriminate and are rejected at load.
+
 Every condition receives the same task, fixture, model, harness, and tool
 profile. The treatment additionally receives the selected harness's native
 isolated skill installation. In `forced` mode the adapter explicitly activates

--- a/skills/skill-eval-loop/references/eval-suite-schema.md
+++ b/skills/skill-eval-loop/references/eval-suite-schema.md
@@ -41,6 +41,20 @@ Use:
 - `forced` to expand the target skill before the task, or `autonomous` to
   expose only its metadata and measure whether the model reads `SKILL.md`.
 
+Each case may declare an optional `counter_reference` beside `reference`:
+
+```json
+"reference": {"response": "a correct answer"},
+"counter_reference": {"response": "a plausible but wrong answer"}
+```
+
+`reference` proves the graders accept a correct answer. `counter_reference`
+proves they reject a wrong one. Both are graded before any trial runs, and a
+counter-reference that passes stops the run: graders that accept everything
+report the same verdict for both conditions, so the paired comparison says
+nothing. A counter-reference is part of the case, so adding one changes the case
+hash and the provenance manifest needs re-registering.
+
 Every condition receives the same task, fixture, model, harness, and tool
 profile. The treatment additionally receives the selected harness's native
 isolated skill installation. In `forced` mode the adapter explicitly activates

--- a/skills/skill-eval-loop/scripts/eval_spec.py
+++ b/skills/skill-eval-loop/scripts/eval_spec.py
@@ -348,6 +348,12 @@ def load_suite(skill_path: Path, evals_path: Path | None = None) -> dict[str, An
             raise ValueError(f"{label}.reference must be an object")
         if not isinstance(reference.get("response", ""), str):
             raise ValueError(f"{label}.reference.response must be a string")
+        counter_reference = case.get("counter_reference")
+        if counter_reference is not None:
+            if not isinstance(counter_reference, dict):
+                raise ValueError(f"{label}.counter_reference must be an object")
+            if not isinstance(counter_reference.get("response", ""), str):
+                raise ValueError(f"{label}.counter_reference.response must be a string")
         normalized = dict(case)
         normalized["id"] = case_id
         normalized["prompt"] = prompt.strip()

--- a/skills/skill-eval-loop/scripts/eval_spec.py
+++ b/skills/skill-eval-loop/scripts/eval_spec.py
@@ -19,6 +19,18 @@ GRADER_TYPES = {
     "json_exact",
     "model_rubric",
 }
+# Counter-reference grades a wrong *response* on the gold reference workspace.
+# Workspace-only graders (file_exists / json_exact) cannot discriminate and must
+# not be paired with counter_reference without a response-sensitive grader.
+RESPONSE_SENSITIVE_GRADER_TYPES = frozenset(
+    {
+        "response_contains",
+        "response_not_contains",
+        "response_regex",
+        "markdown_table_column_regex",
+        "model_rubric",
+    }
+)
 SKILL_LOADING_POLICIES = {"required", "optional", "forbidden"}
 SUITE_TYPES = {"capability", "regression"}
 DATASET_ORIGINS = {"author_derived", "held_out", "production_regression"}
@@ -352,7 +364,12 @@ def load_suite(skill_path: Path, evals_path: Path | None = None) -> dict[str, An
         if counter_reference is not None:
             if not isinstance(counter_reference, dict):
                 raise ValueError(f"{label}.counter_reference must be an object")
-            if not isinstance(counter_reference.get("response", ""), str):
+            if "response" not in counter_reference:
+                raise ValueError(
+                    f"{label}.counter_reference.response is required "
+                    "(empty objects are not allowed)"
+                )
+            if not isinstance(counter_reference["response"], str):
                 raise ValueError(f"{label}.counter_reference.response must be a string")
         normalized = dict(case)
         normalized["id"] = case_id
@@ -366,6 +383,17 @@ def load_suite(skill_path: Path, evals_path: Path | None = None) -> dict[str, An
         grader_names = [grader["name"] for grader in normalized["graders"]]
         if len(grader_names) != len(set(grader_names)):
             raise ValueError(f"{label} has a duplicate grader name")
+        if counter_reference is not None and not any(
+            grader["type"] in RESPONSE_SENSITIVE_GRADER_TYPES
+            for grader in normalized["graders"]
+        ):
+            raise ValueError(
+                f"{label}.counter_reference requires at least one "
+                "response-sensitive grader "
+                f"({', '.join(sorted(RESPONSE_SENSITIVE_GRADER_TYPES))}); "
+                "file_exists/json_exact alone cannot discriminate a wrong "
+                "response on the gold reference workspace"
+            )
         if schema_version == 2:
             for grader_index, grader in enumerate(
                 normalized["graders"],

--- a/skills/skill-eval-loop/scripts/run_skill_eval.py
+++ b/skills/skill-eval-loop/scripts/run_skill_eval.py
@@ -143,6 +143,52 @@ def _model_graders(
     return external, records
 
 
+def _grade_counter_reference(
+    *,
+    case: dict,
+    suite_root: Path,
+    output_dir: Path,
+    harness: str,
+    executable: str,
+    judge_model: str | None,
+    judge_timeout_seconds: int,
+    eval_run: Any,
+) -> dict | None:
+    """Grade a deliberately wrong answer, when the case declares one.
+
+    The reference check above proves the graders accept a correct answer. It
+    cannot show they reject an incorrect one, and graders that accept everything
+    report a confident verdict for both conditions of the paired run.
+
+    Returns the grading, or None when the case declares no counter-reference.
+    """
+    counter_reference = case.get("counter_reference")
+    if not counter_reference:
+        return None
+    response = counter_reference.get("response", "")
+    with tempfile.TemporaryDirectory(prefix="skill-eval-counter-") as temp:
+        workspace = Path(temp)
+        _prepare_workspace(suite_root, case, workspace, reference=True)
+        external, _ = _model_graders(
+            case=case,
+            response=response,
+            trace_dir=output_dir / "counter-reference-judges" / case["id"],
+            root=output_dir,
+            harness=harness,
+            executable=executable,
+            judge_model=judge_model,
+            timeout_seconds=judge_timeout_seconds,
+            eval_run=eval_run,
+            display_context=f"counter-reference · {case['id']}",
+        )
+        return grade_case(
+            workspace=workspace,
+            response=response,
+            graders=case["graders"],
+            external_grades=external,
+        )
+
+
 def _validate_references(
     *,
     suite_root: Path,
@@ -179,6 +225,21 @@ def _validate_references(
             )
         if grading["summary"]["failed"]:
             raise ValueError(f"reference solution failed graders for case {case['id']}")
+        counter_grading = _grade_counter_reference(
+            case=case,
+            suite_root=suite_root,
+            output_dir=output_dir,
+            harness=harness,
+            executable=executable,
+            judge_model=judge_model,
+            judge_timeout_seconds=judge_timeout_seconds,
+            eval_run=eval_run,
+        )
+        if counter_grading is not None and not counter_grading["summary"]["failed"]:
+            raise ValueError(
+                f"counter-reference passed graders for case {case['id']}; "
+                "the graders do not separate a correct answer from a wrong one"
+            )
         records.append(
             {
                 "case_id": case["id"],

--- a/skills/skill-eval-loop/scripts/run_skill_eval.py
+++ b/skills/skill-eval-loop/scripts/run_skill_eval.py
@@ -163,9 +163,9 @@ def _grade_counter_reference(
     Returns the grading, or None when the case declares no counter-reference.
     """
     counter_reference = case.get("counter_reference")
-    if not counter_reference:
+    if counter_reference is None:
         return None
-    response = counter_reference.get("response", "")
+    response = counter_reference["response"]
     with tempfile.TemporaryDirectory(prefix="skill-eval-counter-") as temp:
         workspace = Path(temp)
         _prepare_workspace(suite_root, case, workspace, reference=True)

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -30,7 +30,14 @@ from recommend_models import (  # noqa: E402
     infer_tier,
     parse_pi_models,
 )
-from run_skill_eval import _run_condition, condition_order, plan_run, run_suite  # noqa: E402
+from run_skill_eval import (  # noqa: E402
+    _grade_counter_reference,
+    _run_condition,
+    _validate_references,
+    condition_order,
+    plan_run,
+    run_suite,
+)
 from runtime_adapters import (  # noqa: E402
     HARNESS_NAMES,
     build_invocation,
@@ -494,6 +501,101 @@ class SuiteValidationTests(unittest.TestCase):
             ]
             _write_json(suite_path, suite)
             with self.assertRaisesRegex(ValueError, "rubric"):
+                load_suite(skill)
+
+
+class CounterReferenceTests(unittest.TestCase):
+    """A declared counter-reference must fail the graders.
+
+    The existing reference check proves the graders accept a correct answer. It
+    cannot show they reject a wrong one, and graders that accept everything
+    report a confident verdict for both conditions of a paired run.
+    """
+
+    def _skill_with_counter(self, root: Path, counter_response: str) -> Path:
+        """Add a counter-reference and re-register the case.
+
+        A counter-reference is part of the case, so it changes the case hash.
+        Re-registering it here is the same step an author takes when editing a
+        suite; leaving the manifest stale would fail provenance, which is the
+        behaviour we want everywhere else.
+        """
+        skill = _make_schema3_skill(root)
+        suite_path = skill / "evals" / "evals.json"
+        provenance_path = skill / "evals" / "provenance.json"
+        suite = json.loads(suite_path.read_text(encoding="utf-8"))
+        suite["evals"][0]["counter_reference"] = {"response": counter_response}
+        _write_json(suite_path, suite)
+
+        provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+        provenance["suite_sha256"] = canonical_sha256(suite)
+        provenance["cases"][0]["case_sha256"] = canonical_sha256(suite["evals"][0])
+        _write_json(provenance_path, provenance)
+        return skill
+
+    def _validate(self, skill: Path, output_dir: Path) -> list[dict]:
+        suite = load_suite(skill)
+        return _validate_references(
+            suite_root=skill / "evals",
+            suite=suite,
+            output_dir=output_dir,
+            harness="pi",
+            executable="unused",
+            judge_model=None,
+            judge_timeout_seconds=1,
+            eval_run=None,
+        )
+
+    def test_a_wrong_counter_reference_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            skill = self._skill_with_counter(root, "this answer is wrong")
+            self.assertTrue(self._validate(skill, root / "out"))
+
+    def test_a_counter_reference_that_passes_stops_the_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            skill = self._skill_with_counter(root, "done")
+            with self.assertRaisesRegex(ValueError, "counter-reference passed graders"):
+                self._validate(skill, root / "out")
+
+    def test_a_suite_without_a_counter_reference_is_unaffected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            skill = _make_schema3_skill(root)
+            self.assertTrue(self._validate(skill, root / "out"))
+            case = load_suite(skill)["evals"][0]
+            self.assertIsNone(
+                _grade_counter_reference(
+                    case=case,
+                    suite_root=skill / "evals",
+                    output_dir=root / "out",
+                    harness="pi",
+                    executable="unused",
+                    judge_model=None,
+                    judge_timeout_seconds=1,
+                    eval_run=None,
+                )
+            )
+
+    def test_counter_reference_must_be_an_object(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            skill = _make_schema3_skill(Path(temp))
+            suite_path = skill / "evals" / "evals.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            suite["evals"][0]["counter_reference"] = "wrong"
+            _write_json(suite_path, suite)
+            with self.assertRaisesRegex(ValueError, "counter_reference must be an object"):
+                load_suite(skill)
+
+    def test_counter_reference_response_must_be_a_string(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            skill = _make_schema3_skill(Path(temp))
+            suite_path = skill / "evals" / "evals.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            suite["evals"][0]["counter_reference"] = {"response": 7}
+            _write_json(suite_path, suite)
+            with self.assertRaisesRegex(ValueError, "counter_reference.response must be a string"):
                 load_suite(skill)
 
 

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -598,6 +598,37 @@ class CounterReferenceTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "counter_reference.response must be a string"):
                 load_suite(skill)
 
+    def test_empty_counter_reference_object_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            skill = _make_schema3_skill(Path(temp))
+            suite_path = skill / "evals" / "evals.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            suite["evals"][0]["counter_reference"] = {}
+            _write_json(suite_path, suite)
+            with self.assertRaisesRegex(
+                ValueError, "counter_reference.response is required"
+            ):
+                load_suite(skill)
+
+    def test_counter_reference_requires_a_response_sensitive_grader(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            skill = _make_schema3_skill(Path(temp))
+            suite_path = skill / "evals" / "evals.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            suite["evals"][0]["graders"] = [
+                {
+                    "name": "Creates the result",
+                    "type": "file_exists",
+                    "path": "result.json",
+                }
+            ]
+            suite["evals"][0]["counter_reference"] = {"response": "wrong"}
+            _write_json(suite_path, suite)
+            with self.assertRaisesRegex(
+                ValueError, "requires at least one response-sensitive grader"
+            ):
+                load_suite(skill)
+
 
 class RuntimeTests(unittest.TestCase):
     def test_model_identity_rejects_suffix_collisions(self) -> None:


### PR DESCRIPTION
`_validate_references` already grades each case's reference response and stops
the run when it fails, which proves the graders accept a correct answer. Nothing
proved they reject an incorrect one.

That gap matters here more than it would elsewhere. Graders that accept
everything pass both the control and the treatment, so the run reports a clean
no-difference result and the number means nothing. The failure is invisible in
the output.

Cases may now declare an optional `counter_reference` beside `reference`:

```json
"reference": {"response": "a correct answer"},
"counter_reference": {"response": "a plausible but wrong answer"}
```

It is graded in the same pass, before any trial, and the run stops if it passes:

```
counter-reference passed graders for case X;
the graders do not separate a correct answer from a wrong one
```

Optional, so existing suites behave exactly as before. 67 lines of production
code, reusing the reference path rather than adding a second mechanism.

One adoption note, documented in the schema reference: a counter-reference is
part of the case, so adding one changes the case hash and the provenance
manifest needs re-registering.

Your suite goes from 88 to 93 tests, all passing.


---

Related, and deliberately not changed here: `response_not_contains` passes on an
empty response.

```
empty response, per grader:
  response_contains                -> fail
  response_not_contains            -> PASS
  response_regex                   -> fail
  markdown_table_column_regex      -> fail
```

An agent that returns nothing satisfies every "must not contain X" check. It is
arguably the correct reading, since an empty string genuinely does not contain
the string, and the exposure is narrow because a failed target invocation
already raises before grading. The case that reaches it is a model that responds
but says nothing useful.

Left alone because it is a semantics question about your grader types rather
than a defect, and changing it could alter results for existing suites. Happy to
send it separately if you want the stricter reading.
