### PR TITLE
Say plainly that distribution_policy did not gate the result

### DIFF
--- a/skills/skill-eval-loop/scripts/aggregate_benchmark.py
+++ b/skills/skill-eval-loop/scripts/aggregate_benchmark.py
@@ -596,6 +596,16 @@ def aggregate(run_dir: Path) -> dict:
         "operations": operations,
         "limits": [
             "This is a local paired diagnostic, not a distribution or significance claim.",
+            *(
+                [
+                    "distribution_policy was declared by the suite and not applied to this "
+                    f"result: minimum_pairs={declared_policy.get('minimum_pairs')}, "
+                    f"minimum_effect_size={declared_policy.get('minimum_effect_size')}, "
+                    f"confidence_level={declared_policy.get('confidence_level')}."
+                ]
+                if (declared_policy := suite_snapshot.get("distribution_policy"))
+                else []
+            ),
             (
                 f"{harness} skill exposure is configured by the selected adapter; "
                 "runtime attestation and tool-profile precision vary by harness."

--- a/skills/skill-eval-loop/scripts/run_skill_eval.py
+++ b/skills/skill-eval-loop/scripts/run_skill_eval.py
@@ -584,6 +584,7 @@ def run_suite(
             "dataset_origin": suite["dataset_origin"],
             "tool_profile": suite["tool_profile"],
             "activation_mode": suite["activation_mode"],
+            "distribution_policy": suite.get("distribution_policy"),
             "source_sha256": _sha256_file(Path(suite["source_path"])),
             "cases": [
                 {

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -497,6 +497,45 @@ class SuiteValidationTests(unittest.TestCase):
                 load_suite(skill)
 
 
+class DeclaredPolicyTests(unittest.TestCase):
+    """A declared distribution_policy is recorded and reported as unapplied.
+
+    The schema requires the field and validates its bounds, but no evaluator
+    decision uses it. Saying so in the run artifact keeps it from reading like a
+    threshold the run enforced.
+    """
+
+    def test_limits_name_the_policy_that_did_not_gate_the_result(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _make_run(root, [(True, False), (True, False), (True, True)])
+            snapshot_path = root / "suite_snapshot.json"
+            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            snapshot["distribution_policy"] = {
+                "minimum_pairs": 3,
+                "minimum_effect_size": 0.1,
+                "confidence_level": 0.95,
+            }
+            _write_json(snapshot_path, snapshot)
+            manifest_path = root / "run_manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["suite_sha256"] = _sha256(snapshot_path)
+            _write_json(manifest_path, manifest)
+
+            limits = aggregate(root)["limits"]
+            policy_notes = [line for line in limits if "distribution_policy" in line]
+            self.assertEqual(len(policy_notes), 1)
+            self.assertIn("not applied", policy_notes[0])
+            self.assertIn("minimum_effect_size=0.1", policy_notes[0])
+
+    def test_a_run_without_a_declared_policy_gains_no_note(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _make_run(root, [(True, False), (True, False), (True, True)])
+            limits = aggregate(root)["limits"]
+            self.assertFalse([line for line in limits if "distribution_policy" in line])
+
+
 class RuntimeTests(unittest.TestCase):
     def test_model_identity_rejects_suffix_collisions(self) -> None:
         self.assertTrue(

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -535,6 +535,72 @@ class DeclaredPolicyTests(unittest.TestCase):
             limits = aggregate(root)["limits"]
             self.assertFalse([line for line in limits if "distribution_policy" in line])
 
+    def test_run_suite_retains_declared_policy_in_the_snapshot(self) -> None:
+        """Honesty depends on run_suite writing the field, not only aggregate.
+
+        The aggregate-only fixtures above can stay green if the snapshot write is
+        dropped. A schema-3 fake run proves the production path retains the
+        declared policy and names it as unapplied in limits.
+        """
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            skill = _make_schema3_skill(root)
+            fake_pi = root / "fake-pi"
+            fake_pi.write_text(
+                """#!/usr/bin/env python3
+import json
+import sys
+
+if "--version" in sys.argv:
+    print("fake-pi 1.0")
+    raise SystemExit(0)
+
+treatment = "--skill" in sys.argv
+print(json.dumps({
+    "type": "system",
+    "subtype": "init",
+    "model": "provider/model-1",
+    "session_id": "fixture-session",
+    "skills": ["candidate-skill"] if treatment else [],
+}))
+print(json.dumps({
+    "message": {
+        "role": "assistant",
+        "model": "provider/model-1",
+        "content": [{"type": "text", "text": "done" if treatment else "FAIL"}],
+        "usage": {"input": 1, "output": 1, "totalTokens": 2},
+    }
+}))
+""",
+                encoding="utf-8",
+            )
+            fake_pi.chmod(0o755)
+            output = root / "run"
+            report = run_suite(
+                skill_path=skill,
+                output_dir=output,
+                model="provider/model-1",
+                trials=1,
+                pi_bin=str(fake_pi),
+            )
+            snapshot = json.loads(
+                (output / "suite_snapshot.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                snapshot["distribution_policy"],
+                {
+                    "minimum_pairs": 3,
+                    "minimum_effect_size": 0.1,
+                    "confidence_level": 0.95,
+                },
+            )
+            policy_notes = [
+                line for line in report["limits"] if "distribution_policy" in line
+            ]
+            self.assertEqual(len(policy_notes), 1)
+            self.assertIn("not applied", policy_notes[0])
+            self.assertIn("minimum_effect_size=0.1", policy_notes[0])
+
 
 class RuntimeTests(unittest.TestCase):
     def test_model_identity_rejects_suffix_collisions(self) -> None:


### PR DESCRIPTION
## Summary
- Retains declared `distribution_policy` in `suite_snapshot` and names it in aggregate `limits` as declared and not applied (honesty recording; no gating).
- Merges current `main` (including #13 `counter_reference`) and keeps both `DeclaredPolicyTests` and `CounterReferenceTests`.

## Note vs #14
https://github.com/jon-devlapaz/tink-skills/pull/14 targets `bradAGI:fix/declare-unapplied-policy`, where tip `6adbe3f` deletes `test_skill_eval_loop.py`. This PR is the same feature work merged onto `main` with both test classes preserved. Prefer this branch over #14’s fork tip.

## Test plan
- [x] `python3 -m unittest skills.skill-eval-loop.tests.test_skill_eval_loop` (81 OK)
- [x] `ruff check` on skill-eval-loop scripts/tests
- [ ] Close or supersede #14 once this is preferred