### PR TITLE
Own target runtime attestation in one shared policy path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__/
 *.py[cod]
 .pytest_cache/
+.ruff_cache/
 .eval-runs/
 .hermes/
 .agents/
+.compound-engineering/
+docs/

--- a/skills/skill-eval-loop/scripts/aggregate_benchmark.py
+++ b/skills/skill-eval-loop/scripts/aggregate_benchmark.py
@@ -16,6 +16,7 @@ from runtime_adapters import (
     skill_payload_sha256,
     trace_metadata,
 )
+from runtime_attestation import evaluate_target_trace_attestation
 
 
 CONDITIONS = ("without_skill", "with_skill")
@@ -211,15 +212,15 @@ def _condition_record(
         requested_model=requested_model,
         attestation_trace_path=attestation_trace,
     )
-    if harness == "codex" and attestation_trace is None:
-        invalid.append("attestation_trace_missing")
-    attested_model = metadata.get("actual_model")
-    if metadata.get("model_attested") is not True:
-        invalid.append("model_not_attested")
-    if not model_matches(requested_model, attested_model):
-        invalid.append("model_mismatch")
-    if not model_matches(str(record.get("actual_model", "")), attested_model):
-        invalid.append("manifest_model_mismatch")
+    invalid.extend(
+        evaluate_target_trace_attestation(
+            metadata,
+            harness=harness,
+            requested_model=requested_model,
+            # Empty string, not None: None skips the manifest check.
+            recorded_actual_model=str(record.get("actual_model") or ""),
+        )
+    )
 
     return {
         "success": task_success and not {"timeout", "runtime_error"} & set(invalid),

--- a/skills/skill-eval-loop/scripts/run_skill_eval.py
+++ b/skills/skill-eval-loop/scripts/run_skill_eval.py
@@ -26,12 +26,12 @@ from model_grader import run_model_grade
 from runtime_adapters import (
     HARNESS_NAMES,
     build_invocation,
-    model_matches,
     resolve_harness,
     skill_payload_sha256,
     trace_metadata,
     validate_pinned_model,
 )
+from runtime_attestation import require_target_runtime_attestation
 from workspace_paths import DEFAULT_EVAL_RUNS_ROOT, default_run_output
 
 
@@ -346,29 +346,15 @@ def _run_condition(
             else None
         ),
     )
-    if harness == "codex" and not metadata.get("attestation_trace_path"):
-        raise RuntimeError(
-            f"target model {model} was not attested; persisted Codex rollout "
-            f"is missing; see {trace_path}"
-        )
-    if metadata.get("model_attested") is not True:
-        raise RuntimeError(f"target model {model} was not attested; see {trace_path}")
-    actual_model = metadata.get("actual_model")
-    if not model_matches(model, actual_model):
-        raise RuntimeError(
-            f"requested target model {model} but attested {actual_model}; "
-            f"see {trace_path}"
-        )
-    if (
-        harness == "codex"
-        and condition == "with_skill"
-        and case["_activation_mode"] == "forced"
-        and metadata.get("skill_explicitly_accessed") is not True
-    ):
-        raise RuntimeError(
-            f"forced target skill {skill_path.name} was not explicitly accessed; "
-            f"see {trace_path}"
-        )
+    require_target_runtime_attestation(
+        metadata,
+        harness=harness,
+        requested_model=model,
+        condition=condition,
+        activation_mode=case["_activation_mode"],
+        skill_name=skill_path.name,
+        trace_path=trace_path,
+    )
     if timed_out or completed.returncode != 0:
         status = "timed out" if timed_out else f"exited {completed.returncode}"
         raise RuntimeError(

--- a/skills/skill-eval-loop/scripts/runtime_attestation.py
+++ b/skills/skill-eval-loop/scripts/runtime_attestation.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Target-runtime attestation policy for paired skill evaluation.
+
+``trace_metadata`` parses harness traces. This module owns what must be true
+for a *target* condition. Aggregate re-parses and applies the same policy as
+reason codes without trusting manifest booleans. Write-time callers raise via
+``require_target_runtime_attestation``, a thin adapter over evaluate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from runtime_adapters import model_matches
+
+
+def evaluate_target_trace_attestation(
+    metadata: Mapping[str, Any],
+    *,
+    harness: str,
+    requested_model: str,
+    recorded_actual_model: object | None = None,
+    condition: str | None = None,
+    activation_mode: str | None = None,
+) -> list[str]:
+    """Return machine reason codes for target-trace attestation.
+
+    Empty list means the policy passed. Soft-fail callers (aggregate) extend
+    their ``invalid`` list with these codes. Write-time callers use
+    ``require_target_runtime_attestation``.
+
+    Forced-skill access is checked only when ``condition`` and
+    ``activation_mode`` identify a Codex forced treatment (write-time).
+    """
+    reasons: list[str] = []
+    if harness == "codex" and not metadata.get("attestation_trace_path"):
+        reasons.append("attestation_trace_missing")
+    if metadata.get("model_attested") is not True:
+        reasons.append("model_not_attested")
+    attested_model = metadata.get("actual_model")
+    if not model_matches(requested_model, attested_model):
+        reasons.append("model_mismatch")
+    if recorded_actual_model is not None and not model_matches(
+        str(recorded_actual_model or ""),
+        attested_model,
+    ):
+        reasons.append("manifest_model_mismatch")
+    if (
+        harness == "codex"
+        and condition == "with_skill"
+        and activation_mode == "forced"
+        and metadata.get("skill_explicitly_accessed") is not True
+    ):
+        reasons.append("forced_skill_not_accessed")
+    return reasons
+
+
+def require_target_runtime_attestation(
+    metadata: Mapping[str, Any],
+    *,
+    harness: str,
+    requested_model: str,
+    condition: str,
+    activation_mode: str,
+    skill_name: str,
+    trace_path: Path,
+) -> None:
+    """Raise ``RuntimeError`` when write-time target attestation fails."""
+    reasons = evaluate_target_trace_attestation(
+        metadata,
+        harness=harness,
+        requested_model=requested_model,
+        condition=condition,
+        activation_mode=activation_mode,
+    )
+    if not reasons:
+        return
+    raise RuntimeError(
+        _write_time_message(
+            reasons[0],
+            requested_model=requested_model,
+            actual_model=metadata.get("actual_model"),
+            skill_name=skill_name,
+            trace_path=trace_path,
+        )
+    )
+
+
+def _write_time_message(
+    reason: str,
+    *,
+    requested_model: str,
+    actual_model: object,
+    skill_name: str,
+    trace_path: Path,
+) -> str:
+    if reason == "attestation_trace_missing":
+        return (
+            f"target model {requested_model} was not attested; persisted Codex "
+            f"rollout is missing; see {trace_path}"
+        )
+    if reason == "model_not_attested":
+        return (
+            f"target model {requested_model} was not attested; see {trace_path}"
+        )
+    if reason == "model_mismatch":
+        return (
+            f"requested target model {requested_model} but attested "
+            f"{actual_model}; see {trace_path}"
+        )
+    if reason == "forced_skill_not_accessed":
+        return (
+            f"forced target skill {skill_name} was not explicitly accessed; "
+            f"see {trace_path}"
+        )
+    raise ValueError(f"unhandled target attestation reason: {reason}")

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -47,6 +47,10 @@ from runtime_adapters import (  # noqa: E402
     trace_metadata,
     validate_pinned_model,
 )
+from runtime_attestation import (  # noqa: E402
+    evaluate_target_trace_attestation,
+    require_target_runtime_attestation,
+)
 from workspace_paths import DEFAULT_EVAL_RUNS_ROOT, default_run_output  # noqa: E402
 
 
@@ -733,6 +737,106 @@ class CounterReferenceTests(unittest.TestCase):
                 ValueError, "requires at least one response-sensitive grader"
             ):
                 load_suite(skill)
+
+
+class TargetAttestationOwnerTests(unittest.TestCase):
+    def _ok_metadata(self, **overrides: object) -> dict:
+        metadata = {
+            "attestation_trace_path": Path("/tmp/rollout.jsonl"),
+            "model_attested": True,
+            "actual_model": "provider/model-1",
+            "skill_explicitly_accessed": True,
+        }
+        metadata.update(overrides)
+        return metadata
+
+    def test_evaluate_passes_when_attested(self) -> None:
+        reasons = evaluate_target_trace_attestation(
+            self._ok_metadata(),
+            harness="codex",
+            requested_model="provider/model-1",
+            recorded_actual_model="provider/model-1",
+        )
+        self.assertEqual(reasons, [])
+
+    def test_evaluate_reports_codex_rollout_missing(self) -> None:
+        reasons = evaluate_target_trace_attestation(
+            self._ok_metadata(attestation_trace_path=None, model_attested=False),
+            harness="codex",
+            requested_model="provider/model-1",
+        )
+        self.assertIn("attestation_trace_missing", reasons)
+        self.assertIn("model_not_attested", reasons)
+
+    def test_evaluate_reports_manifest_model_mismatch(self) -> None:
+        reasons = evaluate_target_trace_attestation(
+            self._ok_metadata(actual_model="provider/other"),
+            harness="codex",
+            requested_model="provider/model-1",
+            recorded_actual_model="provider/model-1",
+        )
+        self.assertIn("model_mismatch", reasons)
+        self.assertIn("manifest_model_mismatch", reasons)
+
+    def test_evaluate_fail_closed_on_empty_recorded_model(self) -> None:
+        reasons = evaluate_target_trace_attestation(
+            self._ok_metadata(),
+            harness="codex",
+            requested_model="provider/model-1",
+            recorded_actual_model="",
+        )
+        self.assertIn("manifest_model_mismatch", reasons)
+
+    def test_require_raises_when_forced_skill_not_accessed(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "forced target skill fixture-skill was not explicitly accessed",
+        ):
+            require_target_runtime_attestation(
+                self._ok_metadata(skill_explicitly_accessed=False),
+                harness="codex",
+                requested_model="provider/model-1",
+                condition="with_skill",
+                activation_mode="forced",
+                skill_name="fixture-skill",
+                trace_path=Path("/tmp/trace.jsonl"),
+            )
+
+    def test_require_skips_forced_skill_outside_codex_forced_treatment(self) -> None:
+        require_target_runtime_attestation(
+            self._ok_metadata(skill_explicitly_accessed=False),
+            harness="pi",
+            requested_model="provider/model-1",
+            condition="with_skill",
+            activation_mode="forced",
+            skill_name="fixture-skill",
+            trace_path=Path("/tmp/trace.jsonl"),
+        )
+
+    def test_evaluate_reports_forced_skill_when_write_context_supplied(self) -> None:
+        reasons = evaluate_target_trace_attestation(
+            self._ok_metadata(skill_explicitly_accessed=False),
+            harness="codex",
+            requested_model="provider/model-1",
+            condition="with_skill",
+            activation_mode="forced",
+        )
+        self.assertEqual(reasons, ["forced_skill_not_accessed"])
+
+    def test_require_maps_evaluate_reasons_to_runtime_errors(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "requested target model provider/model-1 but attested provider/other",
+        ):
+            require_target_runtime_attestation(
+                self._ok_metadata(actual_model="provider/other"),
+                harness="codex",
+                requested_model="provider/model-1",
+                condition="without_skill",
+                activation_mode="forced",
+                skill_name="fixture-skill",
+                trace_path=Path("/tmp/trace.jsonl"),
+            )
 
 
 class RuntimeTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Centralize target-runtime attestation in `runtime_attestation.py` so write-time `require` and aggregate `evaluate` share one policy path (fail-closed on empty recorded model; forced Codex skill access stays write-time-only).
- Ignore local CE review artifacts and tool caches (`docs/`, `.ruff_cache/`, `.compound-engineering/`).

## Test plan
- [x] `bash skills/skill-eval-loop/scripts/healthcheck.sh`
- [ ] Spot-check: Codex forced write-time still raises without explicit skill access
- [ ] Spot-check: aggregate reparse still flags `manifest_model_mismatch` / missing attestation

Follow-ups filed: #21, #20, #22, #23, #24.

Made with [Cursor](https://cursor.com)