### PR TITLE
Modularize Skill Scout Tink integration

### DIFF
--- a/skills/skill-scout/SKILL.md
+++ b/skills/skill-scout/SKILL.md
@@ -102,11 +102,6 @@ not a verified artifact. A relative recommendation is not adoption approval —
 pinning, adaptation, private access, testing, and execution stay behind later
 gates.
 
-If the next gate is install into the current project and
-[Tink](https://github.com/jon-devlapaz/tink) is available, prefer proposing
-`tink skill add …` after approval. Scout never runs install; Tink is optional
-for discovery.
-
 Return:
 
 1. **Best-supported choice** or **No qualified choice**
@@ -125,6 +120,12 @@ evidence, evaluation, abstention and escalation, and failure recovery.
 For DISCOVER, VERIFY, source auditing, bounded search, and portable
 `repo-brief` resolution, load
 [references/scouting-workflow.md](references/scouting-workflow.md).
+
+When Tink is available, or the user asks about Tink projects, libraries,
+skillsets, or GitHub inspection, also load
+[references/tink-integration.md](references/tink-integration.md). Tink owns
+inventory and adoption mechanics; Skill Scout owns qualification and the
+recommendation.
 
 Complete when: the report form above is filled for the active mode, a winner or
 abstention is explicit, and any non-read-only next step is gated on approval.

--- a/skills/skill-scout/references/scouting-workflow.md
+++ b/skills/skill-scout/references/scouting-workflow.md
@@ -17,38 +17,45 @@ Cover these default source tiers when applicable, in order:
 
 Treat only skills loaded for **this** project as already installed:
 
-- Prefer `tink skill list` when `tink` is on `PATH` (lists `.agents/skills/`).
-- Otherwise read `<project>/.agents/skills/*/SKILL.md` (skip `README.md` and
-  dot-entries).
+- Prefer the active runtime's supported inventory command.
+- When Tink is available, load
+  [tink-integration.md](tink-integration.md) and use its project inventory.
+- Otherwise read the active runtime's documented project skill root. For the
+  common Agent Skills layout, inspect `<project>/.agents/skills/` and count
+  directories containing `SKILL.md`; skip dot-entries and documentation files.
 - Also note other project skill roots the active harness uses here when present
   (for example `.cursor/skills/`), but do not invent roots.
 
 A skill that exists only under a personal home (for example `~/.agents/skills/`)
 or another repository is **not** Tier A for this project.
 
-### Tier B — other Tink projects (optional reuse index)
+### Tier B — other projects or personal libraries (optional reuse index)
 
 Do **not** search this tier by default. Open it only when the user asks about
 skills in other projects, reuse across repos, or “what have I installed with
 Tink elsewhere.”
 
-When activated and `$TINK_HOME` or `~/.tink` exists, read
-`skills/by-project/*/meta.json`. Each file is a name catalog:
-`{ "name", "root", "skills": [...] }` — not a skill-tree mirror.
+Use only a supported index or inventory surface. When Tink is available, defer
+to [tink-integration.md](tink-integration.md); do not read or infer Tink's
+private catalog layout. Otherwise inspect only indexes or roots the user or
+runtime explicitly identifies.
 
-- Use matching **names** plus the recorded `root` as leads.
-- Open `<root>/.agents/skills/<name>/` only for shortlisted leads (read-only).
-- If the catalog or a `root` is missing/inaccessible, record the gap; do not
+- Use names and recorded source locations as leads.
+- Open only shortlisted leads (read-only).
+- If an index or source is missing or inaccessible, record the gap; do not
   invent contents.
 - Never treat Tier B as satisfying the non-redundancy gate for the current
-  project. A fit here is a candidate to copy in via `tink skill add` after
-  approval, or evidence that a known skill already exists elsewhere.
+  project. A fit here is an adoption candidate, not an active capability.
 
 ### Tier C — public and registries
 
 - official or canonical registries;
 - GitHub repository and skill search;
 - one broader marketplace, curated index, or general web pass.
+
+When a public GitHub URL is known and Tink is available, use the Tink adapter's
+read-only inspection path to establish repository structure before manually
+traversing it. Structural discovery does not qualify a candidate.
 
 Optional supporting local benches (experimental skill sandboxes the user names)
 may be searched after Tier A when relevant; they are not Tier A unless they are
@@ -151,13 +158,14 @@ A search is complete when:
 If those conditions cannot be met, report the gap and abstain or ask one
 high-leverage question. Do not manufacture search saturation or certainty.
 
-## Adoption next gate (Tink-aware, optional)
+## Adoption next gate
 
 When recommending install into the current project:
 
-1. Prefer `tink skill add <source> [--skill <name>]` when `tink` is available.
-2. If Tink is absent, say so and fall back to the harness's documented skill
-   install path — do not block discovery on Tink.
-3. Still require explicit user approval before any install, config change, or
-   candidate-code execution.
-4. After an approved install, suggest `tink skill check` when Tink is present.
+1. Name the runtime's exact supported adoption action.
+2. If Tink is available, use
+   [tink-integration.md](tink-integration.md) for that handoff.
+3. If no supported installer is available, report the gap rather than inventing
+   a copy or symlink workflow.
+4. Require explicit user approval before any install, config change, private
+   access, sandbox test, or candidate-code execution.

--- a/skills/skill-scout/references/tink-integration.md
+++ b/skills/skill-scout/references/tink-integration.md
@@ -1,0 +1,87 @@
+# Tink integration
+
+Load this adapter only when Tink is available, or when the user asks about Tink
+projects, libraries, skillsets, or GitHub inspection. Skill Scout must remain
+useful without Tink.
+
+## Ownership boundary
+
+| Owner | Responsibility |
+| --- | --- |
+| Skill Scout | Interpret the workflow, qualify evidence, normalize candidates, rank finalists, abstain, and define the next gate |
+| Tink | Report project and library inventory, inspect GitHub skill structure, enforce canonical skillset identity, and perform approved adoption |
+
+Tink output is evidence about location, structure, and managed state. It does
+not prove workflow fit, safety, maintenance, or demonstrated behavior. Never
+delegate the recommendation to Tink.
+
+## Read-only inventory
+
+Use Tink's public CLI rather than reading its home or catalog internals:
+
+```bash
+tink skill list
+tink skillset list
+tink skill check
+```
+
+- `tink skill list` reports standalone skills active in the current project.
+- `tink skillset list` reports receipt-backed skillsets active in the current
+  project. It currently lists group names, not member names. For a shortlisted
+  group returned by this command, inspect only
+  `.agents/skills/<name>-skillset/*/SKILL.md` to identify its members; do not
+  scan Tink home or parse private receipt or catalog formats.
+- `tink skill check` validates the project skill tree; it does not rank skills.
+
+Open broader inventory only when the user's contract calls for it:
+
+```bash
+tink skill list --catalog
+tink skill list --library
+tink skillset list --library
+```
+
+Catalog and library entries are reuse leads, not proof that a capability is
+active in the current project. Preserve that distinction in the report.
+
+For a public GitHub candidate, prefer:
+
+```bash
+tink inspect <github-url>
+```
+
+Use its immutable revision, skill paths, and inferred source skillsets to bound
+the audit. `tink inspect` is structural discovery only: inspect shortlisted
+skills for instructions, code, provenance, tests, and risk before qualifying
+them. If it cannot classify an irregular repository, report the uncovered
+structure and continue with bounded read-only inspection rather than guessing.
+
+## Adoption handoff
+
+Skill Scout proposes the exact command and waits. Run no mutation during
+scouting.
+
+For a standalone skill:
+
+```bash
+tink skill add <source> --skill <name>
+```
+
+When `<source>` is an unambiguous local skill directory or canonical library
+name, omit `--skill`. For a skillset, require its explicit canonical
+`<name>-skillset` identity and a pre-authored Tink catalog definition before
+proposing:
+
+```bash
+tink skillset add <name>-skillset
+```
+
+After an approved adoption, validate the resulting project state with:
+
+```bash
+tink skill check
+```
+
+Do not manually copy or symlink around Tink, synthesize catalog metadata, hide
+canonical names, or bypass overwrite and drift refusals. If Tink lacks a needed
+operation, expose that gap as the next product or workflow decision.


### PR DESCRIPTION
## What changed

- isolate Tink-specific inventory and adoption behavior behind a conditional adapter
- keep Skill Scout responsible for evidence qualification, ranking, and abstention
- use public Tink CLI surfaces instead of internal catalog files
- document project, library, skillset, and GitHub inspection semantics

## Why

Skill Scout had accumulated stale Tink implementation details in its portable scouting workflow. This creates a stable ownership boundary while preserving read-only scouting and explicit adoption approval.

## Validation

- skill-creator quick validation
- skill-eval-loop suite audit
- 17 repository unit tests
- live Tink 0.3.7 inspection of mattpocock/skills