### PR TITLE
Use Tink skillset member inventory

### DIFF
--- a/skills/skill-scout/references/tink-integration.md
+++ b/skills/skill-scout/references/tink-integration.md
@@ -27,10 +27,10 @@ tink skill check
 
 - `tink skill list` reports standalone skills active in the current project.
 - `tink skillset list` reports receipt-backed skillsets active in the current
-  project. It currently lists group names, not member names. For a shortlisted
-  group returned by this command, inspect only
-  `.agents/skills/<name>-skillset/*/SKILL.md` to identify its members; do not
-  scan Tink home or parse private receipt or catalog formats.
+  project, grouped with their member skill names. Treat those members as active
+  when evaluating non-redundancy. If an older Tink version omits members, report
+  the inventory gap instead of scanning Tink home or parsing receipt or catalog
+  formats.
 - `tink skill check` validates the project skill tree; it does not rank skills.
 
 Open broader inventory only when the user's contract calls for it:


### PR DESCRIPTION
## What changed

- treat grouped members from tink skillset list as the authoritative active-project inventory
- remove the temporary project-filesystem fallback
- retain an explicit coverage gap for older Tink versions

## Why

Tink 0.3.8 now exposes receipt-backed member names directly, so Skill Scout no longer needs to inspect managed paths.

## Validation

- skill-creator quick validation
- skill-eval-loop suite audit
- 18 repository unit tests
- git diff --check