### PR TITLE
Refine triangulate-me first-principles grounding

### DIFF
--- a/skills/triangulate-me/SKILL.md
+++ b/skills/triangulate-me/SKILL.md
@@ -3,9 +3,11 @@ name: triangulate-me
 description: >
   Run an iterative dialogue that gives each substantive user answer a faithful
   reading, its strongest plausible interpretation, its weakest still-plausible
-  interpretation, and an evidence-sensitive convergence. Use when the user asks
+  interpretation, and an evidence-sensitive convergence, grounding apparently
+  fixed constraints in supported primitives when needed. Use when the user asks
   to triangulate, steelman and stress-test, sharpen a position, expose ambiguity,
-  reconcile competing readings, or reach a robust shared understanding.
+  challenge a false constraint, reconcile competing readings, or reach a robust
+  shared understanding.
 ---
 
 # Triangulate Me
@@ -37,10 +39,15 @@ Apply this sequence:
    foolish position merely because it is easy to reject.
 4. **Crux** — Name the exact premise, definition, value, or missing fact that
    explains the distance between the readings.
-5. **Convergence** — Recommend the most robust next formulation. Preserve the
+5. **First-principles check, when triggered** — If the crux contains a
+   supposedly fixed constraint (such as "must use X," "too expensive," "can't
+   scale," or "that's how it is done"), or a solution justified mainly by
+   analogy or authority, run the grounding pass below. Otherwise skip it.
+6. **Convergence** — Recommend the most robust next formulation. Preserve the
    steel read's value while repairing the stress read's supported vulnerability.
-   State what changed.
-6. **Next question** — Ask one question whose answer resolves the crux. Do not
+   Derive it from the grounded primitives when that check ran, and state what
+   changed.
+7. **Next question** — Ask one question whose answer resolves the crux. Do not
    ask a downstream question while its prerequisite remains unsettled.
    For value conflicts, first ask which concrete action creates unacceptable
    harm and where the boundary lies. Do not jump to identity, policy, or other
@@ -53,9 +60,19 @@ Use this compact form unless the subject needs more explanation:
 **Steel read:** ...
 **Stress read:** ...
 **Crux:** ...
+**Grounding:** ... *(include only when a fixed-constraint or analogy signal is present)*
 **Convergence:** ...
 **Next question:** ...
 ```
+
+## Ground constraints from first principles
+
+Use this as one bounded pass, not as a mandatory seventh interpretation. Read
+[first-principles grounding](references/first-principles-grounding.md) when the
+check is triggered. It defines the constraint classes, primitive reduction,
+rebuild, residuals, and kill test; keep the main response's `Grounding` line
+compact and concrete. Do not use the pass for time-critical incidents or
+ordinary polish without a false-constraint signal.
 
 ## Protect the inquiry
 
@@ -75,9 +92,10 @@ Use this compact form unless the subject needs more explanation:
   and assumptions plainly.
 
 Read [reasoning foundations](references/reasoning-foundations.md) when
-calibrating charity, adversarial pressure, integration, or abstention. Read
-[interaction examples](references/interaction-examples.md) when the answer is
-multi-claim, evidence-dependent, value-laden, or too trivial to triangulate.
+calibrating charity, adversarial pressure, integration, first-principles
+grounding, or abstention. Read [interaction examples](references/interaction-examples.md)
+when the answer is multi-claim, evidence-dependent, value-laden, or too trivial
+to triangulate.
 
 ## Continue and stop
 

--- a/skills/triangulate-me/evals/evals.json
+++ b/skills/triangulate-me/evals/evals.json
@@ -125,6 +125,44 @@
       "counter_reference": {
         "response": "Both sides are valid, so require users to reveal half of their identity as a fair compromise."
       }
+    },
+    {
+      "id": "grounds-false-scale-constraint",
+      "behavior_class": "positive",
+      "routing_class": "should_trigger",
+      "prompt": "Help me pressure-test this architecture: We have to use a queue because real-time updates cannot scale. Give the strongest plausible reading, the weakest reasonable reading, and a better convergence before we commit.",
+      "expected_skill_loading": "required",
+      "graders": [
+        {
+          "name": "Uses the grounding frame when a fixed constraint drives the choice",
+          "type": "response_regex",
+          "pattern": "(?is)Faithful read.*Steel read.*Stress read.*Crux.*Grounding.*Convergence.*Next question"
+        },
+        {
+          "name": "Separates measured capacity from queue convention",
+          "type": "model_rubric",
+          "criteria": [
+            {
+              "requirement": "Treat the claim that real-time updates cannot scale as unproven unless a measurement identifies the binding capacity limit.",
+              "prompt_quote": "real-time updates cannot scale"
+            },
+            {
+              "requirement": "Name supported primitives such as update rate, latency budget, fan-out, or another directly relevant requirement rather than relying on precedent or authority.",
+              "prompt_quote": "We have to use a queue"
+            },
+            {
+              "requirement": "Keep the queue as a candidate architecture, state the residual constraint, and propose a cheap representative load test or other kill test.",
+              "prompt_quote": "before we commit"
+            }
+          ]
+        }
+      ],
+      "reference": {
+        "response": "**Faithful read:** Real-time updates are considered incompatible with the required scale, so a queue is proposed as the remedy.\n\n**Steel read:** A queue may absorb bursts and decouple producers from slower consumers, which could protect a real capacity limit.\n\n**Stress read:** \"Cannot scale\" may be an analogy or unmeasured assumption; the actual limit could be fan-out, connection count, payload size, or an implementation detail, and a queue may add latency without solving it.\n\n**Crux:** Which measured capacity bound makes direct updates fail, and whether the queue addresses that bound.\n\n**Grounding:** Classify the scale claim as a measured fact only if supported by load data; retain the required update rate and latency budget as primitives; reopen the queue-as-requirement assumption; rebuild the smallest transport that meets those bounds; binding residuals are the measured capacity and latency limits; kill-test with representative load.\n\n**Convergence:** Treat the queue as one candidate architecture, not a binding requirement, until the failing capacity and the queue’s effect on it are measured.\n\n**Next question:** What load test or production measurement shows the first capacity bound being exceeded?"
+      },
+      "counter_reference": {
+        "response": "Real-time updates cannot scale, so the queue is clearly required. Adopt a standard queue architecture and optimize it later."
+      }
     }
   ]
 }

--- a/skills/triangulate-me/evals/provenance.json
+++ b/skills/triangulate-me/evals/provenance.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "suite_sha256": "a96496e849e9f8bcc8d61ce3d102540a3beb82bdc0107853fd3334016e58ac85",
+  "suite_sha256": "3e315ca2de0daece585ef9fd0b1c8d71f270534b0cb3534a163f4041d05ba381",
   "cases": [
     {
       "case_id": "separates-need-from-proposed-feature",
@@ -34,6 +34,17 @@
       "artifact": "provenance/preserves-privacy-abuse-value-crux.json",
       "artifact_sha256": "65aa99387d02c29f4f2148a2e0615f743d0224274a644273035610f95cb4bf8d",
       "case_sha256": "ec920ab3a9c4075654f1a758aea1293660452666f3a755639bca987294918d3d"
+    },
+    {
+      "case_id": "grounds-false-scale-constraint",
+      "origin": "author_derived",
+      "source_id": "triangulate-me-author-scenario-grounds-false-scale-constraint",
+      "source_type": "author_scenario",
+      "observed_at": "2026-08-09",
+      "task_author": "Codex with user authorization",
+      "artifact": "provenance/grounds-false-scale-constraint.json",
+      "artifact_sha256": "08907f7ee2bce8f9b3c95b79641416c971c001ce5067bac7692e29e779584510",
+      "case_sha256": "7533ad967ab907202709884f549abb8ec062084ded9d971142f25c0c7864a04e"
     }
   ]
 }

--- a/skills/triangulate-me/evals/provenance/grounds-false-scale-constraint.json
+++ b/skills/triangulate-me/evals/provenance/grounds-false-scale-constraint.json
@@ -1,0 +1,11 @@
+{
+  "case_id": "grounds-false-scale-constraint",
+  "origin": "author_derived",
+  "purpose": "Test whether the skill grounds an apparently fixed scale constraint in measured capacity and primitives before accepting a queue as required.",
+  "derived_from": [
+    "The first-principles constraint classification and rebuild protocol",
+    "The existing triangulation faithful/steel/stress/crux/convergence loop",
+    "The requirement to preserve evidence gates and avoid false compromise"
+  ],
+  "expected_failure_without_skill": "Accept the queue as mandatory because real-time updates supposedly cannot scale, without identifying the capacity bound, supported primitives, or a falsifying load test."
+}

--- a/skills/triangulate-me/references/first-principles-grounding.md
+++ b/skills/triangulate-me/references/first-principles-grounding.md
@@ -1,0 +1,44 @@
+# First-principles grounding
+
+Use this one-pass diagnostic when a supposedly fixed constraint or borrowed
+solution is materially driving the user's position. Do not apply it to every
+answer.
+
+## Procedure
+
+1. **List and classify claimed constraints.** Mark each as `physics/math`,
+   `regulation/contract`, `measured fact`, or `convention/analogy/authority`.
+   The first three are binding unless their evidence is wrong; the last is a
+   provisional assumption.
+2. **Reduce to supported primitives.** Keep required inputs, true
+   non-negotiables, relevant bounds, and primary requirements. Support each with
+   a measurement, derivation, or directly stated requirement—not precedent,
+   vendor pricing, or authority alone.
+3. **Discard or reopen unsupported assumptions.** Give each convention or
+   analogy a concrete falsifier. Do not silently carry it into the solution.
+4. **Rebuild from the remainder.** Derive the simplest solution that satisfies
+   binding constraints, preferring fewer moving parts over imitation. If a
+   known-good standard already fits the verified constraints, keep it rather
+   than rebuilding for novelty.
+5. **Name residuals and the kill test.** State the real limits that remain and
+   the cheapest check that could falsify the rebuild. Stop after one pass; do
+   not recurse without new evidence.
+
+## Response contract
+
+When this check runs, make the `Grounding` line compact but concrete. Include:
+
+- constraint classifications;
+- supported primitives;
+- discarded or reopened assumptions;
+- the derived rebuild;
+- binding residuals; and
+- the cheapest kill test.
+
+Keep verified physics, contracts, and measured capacity intact. First principles
+is not permission to wish away hard limits or to turn an urgent incident into a
+greenfield redesign.
+
+## Source
+
+Derived from [cc-thinking-skills — thinking-first-principles](https://github.com/tjboudreaux/cc-thinking-skills/blob/main/skills/thinking-first-principles/SKILL.md).

--- a/skills/triangulate-me/references/interaction-examples.md
+++ b/skills/triangulate-me/references/interaction-examples.md
@@ -36,6 +36,34 @@ as a hypothesis, name the absent measurement, and ask for or perform the next
 diagnostic check. A valid convergence can be: "Treat datastore replacement as
 unproven until the write bottleneck is localized."
 
+## Fixed constraint with a borrowed solution
+
+User answer:
+
+> We have to use a queue because real-time updates cannot scale.
+
+Use the first-principles lens only because the claimed scale constraint is doing
+the work:
+
+- **Faithful read:** Real-time updates are considered incompatible with the
+  required scale, so a queue is proposed as the remedy.
+- **Steel read:** A queue may absorb bursts and decouple producers from slower
+  consumers, which could protect a real capacity limit.
+- **Stress read:** "Cannot scale" may be an analogy or unmeasured assumption;
+  the actual limit could be fan-out, connection count, payload size, or an
+  implementation detail, and a queue may add latency without solving it.
+- **Crux:** Which measured capacity bound makes direct updates fail, and whether
+  the queue addresses that bound.
+- **Grounding:** Classify the scale claim as a measured fact only if supported
+  by load data; retain the required update rate and latency budget as primitives;
+  reopen the queue-as-requirement assumption; rebuild the smallest transport
+  that meets those bounds; kill-test it with a representative load.
+- **Convergence:** Treat the queue as one candidate architecture, not a binding
+  requirement, until the failing capacity and the queue's effect on it are
+  measured.
+- **Next question:** What load test or production measurement shows the first
+  capacity bound being exceeded?
+
 ## Value conflict
 
 User answer:

--- a/skills/triangulate-me/references/reasoning-foundations.md
+++ b/skills/triangulate-me/references/reasoning-foundations.md
@@ -3,6 +3,22 @@
 Use these sources as constraints on the protocol, not as authority to invent
 content the user did not supply.
 
+## First-principles grounding
+
+The companion `thinking-first-principles` skill distinguishes binding limits
+from assumptions borrowed from convention, analogy, precedent, or authority. It
+then decomposes the problem into independently supported primitives, rebuilds
+from those primitives, and defines a cheap falsification test.
+
+- Source: [cc-thinking-skills — thinking-first-principles](https://github.com/tjboudreaux/cc-thinking-skills/blob/main/skills/thinking-first-principles/SKILL.md)
+- Operational rule: activate this lens only when a supposedly fixed constraint
+  is doing material work. Classify it, preserve verified physics/contracts/
+  measured facts, reopen unsupported conventions, and derive the convergence
+  from the remaining primitives.
+- Limit: first-principles grounding is a single bounded diagnostic pass. It is
+  not a demand to re-derive a known-good standard, ignore hard constraints, or
+  turn an urgent incident into a greenfield redesign.
+
 ## Grilling lineage
 
 Matt Pocock's `grill-me` and `grilling` skills model an inquiry as a decision


### PR DESCRIPTION
## What changed

- Added conditional first-principles grounding to `triangulate-me`.
- Extracted the detailed grounding procedure into a progressive-disclosure reference.
- Added a fixed-constraint interaction example and a four-case eval/provenance update.
- Refreshed the Tink-managed live skill copy from the source package.

## Why

Keep the main conversational protocol compact while grounding apparently fixed constraints in supported primitives, measured facts, and explicit kill tests when that lens is warranted.

## Validation

- Skill validation passed for source and live copies.
- Eval audit passed for source and live copies: 4 cases with valid provenance.
- `tink skill check` passed.
- 18 promotion tests passed.
- `git diff --check` passed.

The unrelated untracked `docs/` artifacts were intentionally excluded.