### PR TITLE
Make Skill Scout online discovery deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Research-only ranking under constraints (workflow fit, safety, demonstrated
 behavior, and related gates). Modes: COMPARE, VERIFY, DISCOVER, or ABSTAIN/BUILD.
 DISCOVER inventories active project skills and the Tink library first, presents
 at most three qualified local candidates, then separately asks whether to pursue
-one and whether to search online. Cross-project catalog history is optional.
-Detail:
+one and whether to search online. Authorized online discovery checks the first
+applicable structured source before evidence-triggered GitHub and general-web
+expansion. Cross-project catalog history is optional. Detail:
 [skills/skill-scout/SKILL.md](skills/skill-scout/SKILL.md).
 
 ## skill-eval-loop

--- a/skills/skill-scout/SKILL.md
+++ b/skills/skill-scout/SKILL.md
@@ -79,10 +79,13 @@ In DISCOVER:
    search online; stop.
 
 Search online only after opt-in; an original request that explicitly requires
-online search is opt-in. Do not force a local candidate when none qualifies.
+online search is opt-in. Follow the ordered source and stopping rules in the
+scouting workflow. Broaden sources for missing candidates or decision-blocking
+coverage; deepen finalist evidence for risk. Do not conflate the two. Do not
+force a local candidate when none qualifies.
 
 Complete when: the local checkpoint is reported, or authorized online search
-has produced candidates for Step 4.
+has reached its documented stop with finalists or an explicit coverage gap.
 
 ## 6. Recommend, abstain, and name the next gate
 

--- a/skills/skill-scout/evals/evals.json
+++ b/skills/skill-scout/evals/evals.json
@@ -206,6 +206,171 @@
       "counter_reference": {
         "response": "Run `tink skill add https://github.com/example-org/incident-briefs/tree/9f3e2c1` now."
       }
+    },
+    {
+      "id": "one-off-stays-inline-without-scouting",
+      "behavior_class": "edge",
+      "routing_class": "should_trigger",
+      "prompt": "`README.md` has one heading, `Quick start`, that should be `Quick Start`. What is the next action? Do not edit or inspect anything.",
+      "expected_skill_loading": "required",
+      "graders": [
+        {
+          "name": "States the direct heading correction",
+          "type": "response_regex",
+          "pattern": "(?is)\\b(?:change|rename|correct)\\b.{0,80}\\bQuick Start\\b"
+        },
+        {
+          "name": "Does not propose inventory",
+          "type": "response_not_contains",
+          "value": "inventory"
+        },
+        {
+          "name": "Does not propose survey",
+          "type": "response_not_contains",
+          "value": "survey"
+        },
+        {
+          "name": "Does not propose search",
+          "type": "response_not_contains",
+          "value": "search"
+        },
+        {
+          "name": "Does not propose scouting",
+          "type": "response_not_contains",
+          "value": "scout"
+        }
+      ],
+      "reference": {
+        "response": "Change the README.md heading from `Quick start` to `Quick Start`."
+      },
+      "counter_reference": {
+        "response": "First inspect the local inventory and search for existing utilities; then change the heading to `Quick Start`."
+      }
+    },
+    {
+      "id": "qualified-structured-pass-stops-expansion",
+      "behavior_class": "positive",
+      "routing_class": "should_trigger",
+      "prompt": "Online discovery has already been approved for a recurring AcmeCloud deployment-audit brief. AcmeCloud publishes an official skill collection, and its `deploy-audit` entry has a canonical pinned source with a valid SKILL.md, documented read-only behavior, tests, and evidence that passes every qualification gate for this brief. Identify the procedure-selected structured source, decide whether to expand to GitHub or general-web search, and name the next gate. Do not search, install, or execute anything.",
+      "expected_skill_loading": "required",
+      "graders": [
+        {
+          "name": "Selects the qualified structured-source result",
+          "type": "response_regex",
+          "pattern": "(?i)\\bdeploy-audit\\b"
+        },
+        {
+          "name": "Stops before broader-source expansion",
+          "type": "response_regex",
+          "pattern": "(?is)\\b(?:stop|do not expand|no need to expand)\\b(?:(?:[\\s\\S]{0,220}\\bGitHub\\b[\\s\\S]{0,220}\\b(?:general[- ]web|broader web)\\b)|(?:[\\s\\S]{0,220}\\b(?:general[- ]web|broader web)\\b[\\s\\S]{0,220}\\bGitHub\\b))"
+        },
+        {
+          "name": "Keeps the later action approval-gated",
+          "type": "response_regex",
+          "pattern": "(?i)\\bapproval\\b"
+        },
+        {
+          "name": "Stops both GitHub and general-web expansion",
+          "type": "model_rubric",
+          "criteria": [
+            {
+              "requirement": "Select deploy-audit and stop source discovery because the applicable named-provider structured pass produced a qualified candidate. Reject any further GitHub or general-web expansion, even if the answer proposes GitHub only for comparison, and keep adoption or execution behind approval.",
+              "prompt_quote": "AcmeCloud publishes an official skill collection"
+            }
+          ]
+        }
+      ],
+      "reference": {
+        "response": "Best-supported choice: deploy-audit from AcmeCloud's official structured collection. It already qualifies, so stop discovery here; do not expand to GitHub or general-web search. Next gate: request approval before any later adoption or execution."
+      },
+      "counter_reference": {
+        "response": "Deploy-audit qualifies. Search GitHub first for comparison, then stop before general-web expansion. Request approval before adoption."
+      }
+    },
+    {
+      "id": "coverage-gap-escalates-by-source-not-inspection-risk",
+      "behavior_class": "edge",
+      "routing_class": "should_trigger",
+      "prompt": "Online discovery is approved for a recurring public release-evidence workflow. This is a generic capability request: no product or provider is named. Assume the first structured source selected by the governing procedure yields no qualified candidate: one lead lacks demonstrated behavior and another is not a valid skill directory. Identify that first source and state the constrained next source pass. Assume the next pass finds `release-evidence` in a repository with a valid SKILL.md, but its static materials leave network behavior and permission boundaries unresolved; say when, if ever, general-web search may follow and state the separate finalist-inspection decision. Do not access private sources, search, install, or execute anything.",
+      "expected_skill_loading": "required",
+      "graders": [
+        {
+          "name": "Escalates from skills.sh to GitHub structural discovery",
+          "type": "response_regex",
+          "pattern": "(?is)\\bskills\\.sh\\b[\\s\\S]{0,500}\\bGitHub(?:[- ]source)?\\b[\\s\\S]{0,600}\\b(?:valid\\s+)?SKILL\\.md\\b"
+        },
+        {
+          "name": "Uses generic web only after the remaining coverage gap",
+          "type": "response_regex",
+          "pattern": "(?is)\\b(?:generic|general|broader)[ -](?:web|search)\\b[\\s\\S]{0,500}\\b(?:only|after)\\b[\\s\\S]{0,500}\\b(?:material|coverage|unresolved|no qualified)\\b"
+        },
+        {
+          "name": "Separates inspection depth from search breadth",
+          "type": "model_rubric",
+          "criteria": [
+            {
+              "requirement": "Because this generic request names no product or provider, use skills.sh as the first structured source. After its assumed failure, expand to a bounded GitHub search constrained to valid SKILL.md structure; use general web only if the GitHub pass still leaves a material decision-blocking coverage gap. Separately require deeper finalist inspection of release-evidence's network behavior, permissions, tests, and provenance, without treating higher inspection depth as a reason to expand source breadth.",
+              "prompt_quote": "generic capability request: no product or provider is named"
+            }
+          ]
+        }
+      ],
+      "reference": {
+        "response": "Breadth: because no provider is named, use skills.sh as the first structured source. Since that pass produced no qualified candidate, next use a bounded GitHub structural pass constrained to valid SKILL.md directories. Use general-web search only after that GitHub pass if a material, decision-blocking coverage gap remains. Depth: independently inspect release-evidence's network behavior, permission boundaries, tests, and provenance. Greater inspection depth resolves finalist risk; it does not by itself justify expanding sources. Any private access, adoption, or execution remains approval-gated."
+      },
+      "counter_reference": {
+        "response": "Start with a GitHub structural search, then check skills.sh. Because network uncertainty is risky, immediately search the general web; the valid SKILL.md means the finalist needs no deeper inspection."
+      }
+    },
+    {
+      "id": "ordered-query-and-cap-accounting",
+      "behavior_class": "edge",
+      "routing_class": "should_trigger",
+      "prompt": "Online research is approved for a recurring audit skill. Fit 1 is strongest. Return a concise discovery report from these staged logs: retained lineages, finalists, and whether another source pass is justified. Do not search or act. Source pass one, structured index, family one (user terminology), returned in rank order: Clover (C, rank 1, unresolved, fit 1); Clover Mirror (C, rank 2, unresolved, fit 1); Elm (E, rank 3, unresolved, fit 2). These results leave a material license-coverage gap and no qualifier. Its family two (underlying mechanism) returned: Fir (F, rank 4, unresolved, fit 3); Gale (G, rank 5, unresolved, fit 4). The source still has no qualifier and the gap remains. Source pass two, GitHub structural, family one (user terminology), returned in rank order: Amber (A, rank 1, qualified, fit 1); Birch (B, rank 2, qualified, fit 2); Dune (D, rank 3, qualified, fit 3); Harbor (H, rank 4, qualified, fit 4); Iris (I, rank 5, qualified, fit 5); Juno (J, rank 6, unresolved, fit 1); Kestrel (K, rank 7, unresolved, fit 2). These results close the license-coverage gap and leave no material tie.",
+      "expected_skill_loading": "required",
+      "graders": [
+        {
+          "name": "Normalizes the first duplicate occurrence",
+          "type": "response_regex",
+          "pattern": "(?is)\\bClover\\b.{0,140}\\bfirst occurrence\\b"
+        },
+        {
+          "name": "Reports both source-pass counts",
+          "type": "response_regex",
+          "pattern": "(?i)\\b4 and 7 unique\\b"
+        },
+        {
+          "name": "Reports the global retention cap",
+          "type": "response_regex",
+          "pattern": "(?i)\\b10 non-failed\\b"
+        },
+        {
+          "name": "Selects the overflow finalists",
+          "type": "response_regex",
+          "pattern": "(?i)\\bfinalists?\\s*:\\s*A\\s*,\\s*B\\s*,\\s*D\\b"
+        },
+        {
+          "name": "Stops after the qualified second source pass",
+          "type": "response_regex",
+          "pattern": "(?i)\\bstop after source pass two\\b"
+        },
+        {
+          "name": "Applies ordered bounded discovery",
+          "type": "model_rubric",
+          "criteria": [
+            {
+              "requirement": "Advance pass one's family one to family two only because it has no qualifier and a material gap, then restart pass two at family one; normalize Clover by first occurrence before counting; report the observed per-pass counts of four and seven unique lineages without treating them as caps; retain and report exactly ten non-failed lineages across both passes, omitting G; merge by family ordinal then rank within each pass; select A, B, and D as the three finalists by qualified status then fit, earlier source, and that tuple; and stop because pass two closes the gap with no material tie.",
+              "prompt_quote": "staged logs"
+            }
+          ]
+        }
+      ],
+      "reference": {
+        "response": "Pass one's family one has no qualifier and a material gap, so its family two follows; pass two restarts at family one. Normalize Clover at its first occurrence. The observed source-pass counts are 4 and 7 unique lineages. Retain and report A, B, D, H, I, C, J, E, K, and F: 10 non-failed lineages; omit G. Merge family ordinal then rank within each pass; apply qualified status, fit, earlier source, then that tuple across passes. Finalists: A, B, D. Stop after source pass two: it closes the gap and no material tie remains."
+      },
+      "counter_reference": {
+        "response": "Start pass one at family two, carry family two into pass two, count Clover Mirror separately, retain all 11 non-failed lineages, choose C, E, G, and continue to a third source pass."
+      }
     }
   ]
 }

--- a/skills/skill-scout/evals/provenance.json
+++ b/skills/skill-scout/evals/provenance.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "suite_sha256": "283b792ca0a367164096164646c7f60e07f8c60b34dc6d214d4c327851e4a747",
+  "suite_sha256": "573ccb23af7555e47f155f7761187032a0ef386af002b785227c4366bd8019db",
   "cases": [
     {
       "case_id": "local-fit-beats-reputation",
@@ -56,6 +56,50 @@
       "artifact": "provenance/tink-adoption-remains-a-gated-handoff.json",
       "artifact_sha256": "7fd4d1dce115969ccc928dab0a49432a2eaf39c845631ebd501feaa4dbc87fea",
       "case_sha256": "ba7f3ee539f7794aa5946b9004f65ef324423da98e71ec75e5ba3a19e26fe7f1"
+    },
+    {
+      "case_id": "one-off-stays-inline-without-scouting",
+      "origin": "author_derived",
+      "source_id": "skill-scout-author-scenario-one-off-stays-inline-without-scouting",
+      "source_type": "author_scenario",
+      "observed_at": "2026-08-10",
+      "task_author": "independent eval author",
+      "artifact": "provenance/one-off-stays-inline-without-scouting.json",
+      "artifact_sha256": "289ca635f22239ed53d63750b921efffd28828fbf40f532e11bb9da4074a1b02",
+      "case_sha256": "c415f90b32c391a872fd449d617c57292a6a4b8b7d102b6a61c4ee52defeb895"
+    },
+    {
+      "case_id": "qualified-structured-pass-stops-expansion",
+      "origin": "author_derived",
+      "source_id": "skill-scout-author-scenario-qualified-structured-pass-stops-expansion",
+      "source_type": "author_scenario",
+      "observed_at": "2026-08-10",
+      "task_author": "independent eval author",
+      "artifact": "provenance/qualified-structured-pass-stops-expansion.json",
+      "artifact_sha256": "176585baca4e7c5422bc7721754b3a9d85fe1aab0cf51c4c1dc09edef98bb4f4",
+      "case_sha256": "cb89fa4c56bbd82e34de7cfca876cb7dd08170639ee421f16322ff35d041cd93"
+    },
+    {
+      "case_id": "coverage-gap-escalates-by-source-not-inspection-risk",
+      "origin": "author_derived",
+      "source_id": "skill-scout-author-scenario-coverage-gap-escalates-by-source-not-inspection-risk",
+      "source_type": "author_scenario",
+      "observed_at": "2026-08-10",
+      "task_author": "independent eval author",
+      "artifact": "provenance/coverage-gap-escalates-by-source-not-inspection-risk.json",
+      "artifact_sha256": "755c5b704463fecb78cbf35cb191280d6d869d9da1fec460c04eb86203c1c3a6",
+      "case_sha256": "738e5e5cf0d03aa0edd99af026497e5f849178c3c0876c71874e3b03e48bcc99"
+    },
+    {
+      "case_id": "ordered-query-and-cap-accounting",
+      "origin": "author_derived",
+      "source_id": "skill-scout-author-scenario-ordered-query-and-cap-accounting",
+      "source_type": "author_scenario",
+      "observed_at": "2026-08-10",
+      "task_author": "independent eval author",
+      "artifact": "provenance/ordered-query-and-cap-accounting.json",
+      "artifact_sha256": "71cc85cdddbcaa068e56f0bca6c597d9980c90649b75d6afd2db4ba0d8cce0b7",
+      "case_sha256": "01ad2e9161f0c944313cc5ce8c2efdf394e4183ceb36db4a3867ffa8ace0b647"
     }
   ]
 }

--- a/skills/skill-scout/evals/provenance/coverage-gap-escalates-by-source-not-inspection-risk.json
+++ b/skills/skill-scout/evals/provenance/coverage-gap-escalates-by-source-not-inspection-risk.json
@@ -1,0 +1,9 @@
+{
+  "case_id": "coverage-gap-escalates-by-source-not-inspection-risk",
+  "origin": "author_derived",
+  "purpose": "Prove a generic request searches skills.sh first, then bounded valid-SKILL.md GitHub discovery after failure, and general web only for a remaining material gap while finalist inspection depth stays independent.",
+  "derived_from": [
+    "Skill Scout bounded discovery, valid-skill structure, qualification, and evidence rules"
+  ],
+  "expected_failure_without_skill": "Guess a provider source, search GitHub before skills.sh, skip valid-SKILL.md constraints, use general web before its fallback condition, or conflate high-risk inspection with broader search."
+}

--- a/skills/skill-scout/evals/provenance/one-off-stays-inline-without-scouting.json
+++ b/skills/skill-scout/evals/provenance/one-off-stays-inline-without-scouting.json
@@ -1,0 +1,9 @@
+{
+  "case_id": "one-off-stays-inline-without-scouting",
+  "origin": "author_derived",
+  "purpose": "Prove a natural one-off README capitalization request receives only the direct next action.",
+  "derived_from": [
+    "Skill Scout lightest-mode and one-off inline boundary"
+  ],
+  "expected_failure_without_skill": "Propose preliminary inventory, survey, search, or scouting before the direct correction."
+}

--- a/skills/skill-scout/evals/provenance/ordered-query-and-cap-accounting.json
+++ b/skills/skill-scout/evals/provenance/ordered-query-and-cap-accounting.json
@@ -1,0 +1,9 @@
+{
+  "case_id": "ordered-query-and-cap-accounting",
+  "origin": "author_derived",
+  "purpose": "Prove per-source family reset, ordered advancement, first-occurrence normalization, caps, and finalist overflow.",
+  "derived_from": [
+    "Skill Scout ordered query, retention, and finalist-cap rules"
+  ],
+  "expected_failure_without_skill": "Skip a family reset, reorder families, count a duplicate twice, conflate caps, choose wrong finalists, or expand without a gap."
+}

--- a/skills/skill-scout/evals/provenance/qualified-structured-pass-stops-expansion.json
+++ b/skills/skill-scout/evals/provenance/qualified-structured-pass-stops-expansion.json
@@ -1,0 +1,9 @@
+{
+  "case_id": "qualified-structured-pass-stops-expansion",
+  "origin": "author_derived",
+  "purpose": "Prove a named-provider online search stops before both GitHub and general-web expansion when its applicable structured source yields a qualified candidate.",
+  "derived_from": [
+    "Skill Scout bounded online discovery and qualification-before-ranking rules"
+  ],
+  "expected_failure_without_skill": "Continue into GitHub or general-web comparison after a qualified named-provider structured result."
+}

--- a/skills/skill-scout/references/scouting-workflow.md
+++ b/skills/skill-scout/references/scouting-workflow.md
@@ -23,14 +23,34 @@ Run the following algorithm. Tink commands and identity rules live in
    original request already answers the second question, record that opt-in
    instead of asking again. Stop when an answer is needed. An acceptable
    candidate is not authorization to install, test, or execute.
-5. Search online only after an explicit affirmative answer (or an already
-   explicit online-search request). Use at most three query families: user
-   terminology, underlying mechanism, and adjacent documented tools. Cover
-   official sources, GitHub, and one broader index; keep at most ten raw leads
-   and three finalists. If the user declines, record Tier C as declined.
+5. Search online only after explicit opt-in. In each source pass, restart this sequence
+   of at most three query families: user terminology, underlying mechanism, and adjacent documented tools.
+   Within that pass, run a later family only while no candidate qualifies, finalists remain materially tied, or a decision-blocking gap remains. Apply this source ladder:
+   - For a named provider, inspect its collection; search [skills.sh](https://skills.sh/)
+     only for no qualifier, a material tie, or a coverage gap. Generic searches
+     start at skills.sh. Repository inspection deepens evidence, not coverage; rankings are leads.
+   - Expand to GitHub code search of valid `SKILL.md` directories only for no
+     qualifier, a material tie, or a gap blocking a defensible recommendation.
+   - Run one general-web or broader-index pass only if the GitHub pass still
+     leaves a material, decision-blocking coverage gap.
+   Within each source pass, merge by `(query-family ordinal, source result rank)`;
+   normalize each lineage on first occurrence before counting. Inspect at most ten
+   unique normalized lineages; reset the cap every required pass. Across all passes,
+   retain/report at most ten non-failed lineages and three finalists. If over capacity,
+   retain qualifiers before unresolved leads, then rank by contract fit, earlier
+   ladder source, and `(query-family ordinal, source result rank)`. Record source,
+   query, date, inspected count,
+   lineages, gaps, and stop reason. Use public read-only surfaces; downloaded CLIs,
+   credentialed APIs, private sources, or execution require separate approval; record a declined search.
 6. Apply every Skill Scout gate before ranking. Each finalist must be pass,
    fail, or unresolved on each gate. Reject failed candidates; abstain when no
    candidate qualifies.
+
+Broaden only for insufficiency, a material tie, or a decision-blocking gap; deepen
+for safety, permissions, compatibility, or execution risk. Stop between passes on a
+defensible set with no material gap. Otherwise complete every applicable rung; an
+empty pass cannot preempt a later source required by a remaining gap. After the final
+applicable source, report unresolved gaps and abstain if they block a recommendation.
 
 For a public GitHub finalist with Tink available, use the adapter's read-only
 inspection path before manual traversal. Inspect repository instructions,
@@ -70,11 +90,9 @@ Do not bypass inaccessible sources. Record the gap instead.
 
 ## Completion and adoption
 
-DISCOVER is complete when project and library inventory (or gaps), shortlist,
-checkpoint answers, online status, normalized lineage, gate results, finalist
-evidence, and coverage gaps are recorded. If online search ran, stop after one
-expansion pass that finds no qualified contender. VERIFY is complete when the
-known candidate is answered against the same evidence standard.
+DISCOVER is complete when project/library inventory or gaps, shortlist, checkpoint
+answers, online status and stop reason, lineage, gate results, finalist evidence,
+and coverage gaps are recorded. VERIFY uses the same evidence standard.
 
 For adoption, name the exact inspected tag or commit and propose the runtime's
 supported action; never substitute a floating branch. Use the Tink adapter when


### PR DESCRIPTION
## Summary

- keep directly solvable one-off tasks inline
- make project and Tink-library inventory the local checkpoint before optional online discovery
- define deterministic provider/generic source ordering, per-source query ordering, lineage normalization, bounded lead retention, and gap-driven stopping
- add four provenance-backed regression cases covering one-offs, structured-source stopping, source escalation versus inspection depth, and cross-source cap accounting

## Why

Skill Scout's online discovery path named broad source classes but did not fully specify their order, stopping precedence, or lead accounting. That could make equivalent runs search different candidates, over-search trivial work, prematurely stop despite a material gap, or starve later sources.

## Impact

Named-provider requests start at the provider's collection; generic requests start at skills.sh. GitHub and general-web expansion occur only when qualification, a material tie, or a decision-blocking coverage gap requires them. Candidate inspection depth remains independent from source breadth, and installation, execution, private access, and other mutations remain separately approval-gated.

## Validation

- Skill Creator structural validation
- schema-3 audit: 9 cases and 9 provenance records
- all 9 references pass deterministic graders; every counter-reference is rejected
- 105 skill-eval-loop tests
- 18 promotion tests
- Ruff
- README/reference link checks
- `tink skill check`: 7 skills
- headless dry-run: 50 planned harness invocations and no output directory
- closing read-only review: 9/9 files covered, no P0/P1/P2 findings

## Residual uncertainty

No live provider/model evaluation was run. Semantic model-rubric behavior and treatment/control lift remain to be confirmed separately before making empirical performance claims.