### PR TITLE
Enforce local artifact boundaries

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,6 +36,14 @@ jobs:
       - name: Check whitespace
         run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD
 
+      - name: Reject tracked local artifacts
+        run: |
+          tracked="$(git ls-files -- .agents/ .compound-engineering/ docs/ce-reviews/)"
+          if [ -n "$tracked" ]; then
+            printf 'Local-only artifacts are tracked:\n%s\n' "$tracked"
+            exit 1
+          fi
+
       - name: List installable skills
         run: |
           npx --yes skills add . --list | tee /tmp/skills-list.txt

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ __pycache__/
 .hermes/
 .agents/
 .compound-engineering/
-docs/
+docs/ce-reviews/


### PR DESCRIPTION
## What

- Keep `.agents/` and `.compound-engineering/` local-only.
- Narrow the broad `docs/` ignore to `docs/ce-reviews/`, allowing intentional repository documentation.
- Add one CI check that fails if Git tracks files under any of the three local-only roots.

## Why

Ignore rules do not prevent forced adds, and ignoring all of `docs/` makes future published documentation invisible by default. This makes the repository boundary precise and enforceable.

## Impact

Two repository-policy files change. No local `.agents/`, `.compound-engineering/`, or `docs/ce-reviews/` content is deleted or committed.

## Root cause

The repository encoded a broad ignore convention but had no tracked-file invariant to enforce the intended local-only boundary.

## Checks

- `git diff --check`
- ignore probes for all three local-only roots and ordinary `docs/`
- 18 promotion-tool unit tests
- 105 skill-eval-loop tests
- Ruff
- installable-skill listing
- README link check
- package-count check