### PR TITLE
Refine skill guidance and decision boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,21 @@ tink skill add jon-devlapaz/tink-skills --skill skill-eval-loop
 tink skill add jon-devlapaz/tink-skills --skill triangulate-me
 ```
 
-Refresh clean imports: `tink skill refresh` (or name one skill). Source may be a
-local path or `--stash`. Do not hand-edit `.tink-source.json` receipts.
+Refresh every clean GitHub import:
+
+```console
+tink skill refresh
+```
+
+Refresh one by naming it: `tink skill refresh NAME`.
+
+Local skills do not refresh. Install a library skill by name with
+`tink skill add NAME`. Do not hand-edit `.tink-source.json` receipts.
 
 ## First success
 
-Both skills are agent workflows. Point your coding agent at the project (with
-skills under `.agents/skills/`) and try:
+Start with the core loop: scout a candidate, then measure it. Point your coding
+agent at the project (with skills under `.agents/skills/`) and try:
 
 **Scout — find a fit (read-only until you approve install):**
 

--- a/skills/skill-scout/SKILL.md
+++ b/skills/skill-scout/SKILL.md
@@ -19,7 +19,9 @@ candidate is a valid result.
 | **COMPARE** | Candidates and material evidence are supplied |
 | **VERIFY** | One known skill, URL, or repository is named |
 | **DISCOVER** | Project and Tink library inventory may satisfy the need; online search is optional |
-| **ABSTAIN/BUILD** | No candidate passes the gates |
+
+**ABSTAIN/BUILD** is the outcome when qualification leaves no candidate, not a
+mode chosen before scouting begins.
 
 Use COMPARE when tools are forbidden or the candidate set is closed; do not
 search more broadly when a lighter mode answers the request.
@@ -75,14 +77,14 @@ In DISCOVER:
 1. Enumerate current-project skills, then the supported Tink library.
 2. Qualify and rank at most three local candidates.
 3. Present each candidate's scope, fit, evidence, and material gaps.
-4. Ask separately whether any candidate is acceptable to pursue and whether to
-   search online; stop.
+4. Ask whether any candidate is acceptable to pursue. If online search is not
+   already authorized, ask for that permission separately; otherwise record the
+   existing opt-in. Stop when an answer is needed.
 
-Search online only after opt-in; an original request that explicitly requires
-online search is opt-in. Follow the ordered source and stopping rules in the
-scouting workflow. Broaden sources for missing candidates or decision-blocking
-coverage; deepen finalist evidence for risk. Do not conflate the two. Do not
-force a local candidate when none qualifies.
+When online search is authorized, follow the ordered source and stopping rules
+in the scouting workflow. Broaden sources for missing candidates or decision-
+blocking coverage; deepen finalist evidence for risk. Do not conflate the two.
+Do not force a local candidate when none qualifies.
 
 Complete when: the local checkpoint is reported, or authorized online search
 has reached its documented stop with finalists or an explicit coverage gap.

--- a/skills/triangulate-me/SKILL.md
+++ b/skills/triangulate-me/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: triangulate-me
 description: >
-  Run an iterative dialogue that gives each substantive user answer a faithful
-  reading, its strongest plausible interpretation, its weakest still-plausible
-  interpretation, and an evidence-sensitive convergence, grounding apparently
-  fixed constraints in supported primitives when needed. Use when the user asks
-  to triangulate, steelman and stress-test, sharpen a position, expose ambiguity,
-  challenge a false constraint, reconcile competing readings, or reach a robust
-  shared understanding.
+  Triangulate a claim through faithful, steel, and stress reads, then identify
+  its crux and evidence-sensitive convergence. Use when the user asks to
+  pressure-test an interpretation, expose the crux between plausible readings,
+  ground a supposedly fixed constraint, or converge without false compromise.
 ---
 
 # Triangulate Me
@@ -24,31 +21,35 @@ a proposal for the user to accept, reject, or revise.
 - Find available facts yourself. Ask the user only for judgments, preferences,
   private context, or evidence you cannot inspect.
 
+**Complete when:** exactly one active claim, choice, or assumption is named. If
+the reply is not substantive, respond normally without running the frame.
+
 ## Triangulate each substantive answer
 
 Apply this sequence:
 
-1. **Faithful read** — Restate only what the answer actually commits to. Keep
-   uncertainty, conditions, and scope intact.
+1. **Faithful read** — Restate only what the answer actually commits to.
+   Complete when every qualifier that changes the meaning remains intact.
 2. **Steel read** — Form the strongest coherent interpretation supported by the
-   answer. Make useful implicit premises explicit, but label any premise the
-   user did not state.
+   answer. Complete when every useful agent-added premise is explicit and
+   labeled.
 3. **Stress read** — Form the weakest interpretation that a reasonable reader
-   could still derive from the answer. Ground it in specific ambiguity,
-   omission, evidence, incentive, tradeoff, or consequence. Never invent a
-   foolish position merely because it is easy to reject.
+   could still derive from the answer. Complete when it names a specific,
+   supported vulnerability—or states that none exists.
 4. **Crux** — Name the exact premise, definition, value, or missing fact that
-   explains the distance between the readings.
+   explains the distance between the readings. Complete when resolving it would
+   materially collapse that distance.
 5. **First-principles check, when triggered** — If the crux contains a
    supposedly fixed constraint (such as "must use X," "too expensive," "can't
    scale," or "that's how it is done"), or a solution justified mainly by
    analogy or authority, run the grounding pass below. Otherwise skip it.
 6. **Convergence** — Recommend the most robust next formulation. Preserve the
    steel read's value while repairing the stress read's supported vulnerability.
-   Derive it from the grounded primitives when that check ran, and state what
-   changed.
+   Complete when it states what was preserved, repaired, or left unresolved;
+   derive it from grounded primitives when the check ran.
 7. **Next question** — Ask one question whose answer resolves the crux. Do not
-   ask a downstream question while its prerequisite remains unsettled.
+   ask a downstream question while its prerequisite remains unsettled. Complete
+   when answering it would settle the current crux.
    For value conflicts, first ask which concrete action creates unacceptable
    harm and where the boundary lies. Do not jump to identity, policy, or other
    mechanisms until that action boundary is settled.
@@ -67,24 +68,24 @@ Use this compact form unless the subject needs more explanation:
 
 ## Ground constraints from first principles
 
-Use this as one bounded pass, not as a mandatory seventh interpretation. Read
+Use this as one bounded pass, separate from the six interpretation fields. Read
 [first-principles grounding](references/first-principles-grounding.md) when the
 check is triggered. It defines the constraint classes, primitive reduction,
-rebuild, residuals, and kill test; keep the main response's `Grounding` line
-compact and concrete. Do not use the pass for time-critical incidents or
-ordinary polish without a false-constraint signal.
+rebuild, residuals, and kill test. Keep the main response's `Grounding` line
+compact and concrete. Reserve the pass for a false-constraint or borrowed-
+solution signal; keep time-critical incidents and ordinary polish on their
+direct path.
 
 ## Protect the inquiry
 
-- Do not infer motives, personality, emotions, or beliefs that the user did not
-  express.
-- Do not treat the steel and stress reads as equally evidenced by default.
-- Do not average positions. Convergence may endorse one reading, revise both,
-  preserve an explicit disagreement, or abstain pending evidence or a prototype.
-- Do not convert a factual dispute into a rhetorical compromise. Name the check
-  that could resolve it.
-- Do not manufacture a stress read when no plausible vulnerability exists. Say
-  so and move to the next unresolved decision.
+- Ground every interpretation in the user's expressed language and context;
+  leave unstated motives, personality, emotions, and beliefs outside the frame.
+- Weight the steel and stress reads according to their evidence.
+- Let convergence endorse one reading, revise both, preserve an explicit
+  disagreement, or abstain pending evidence or a prototype.
+- Route a factual dispute to the named check that could resolve it.
+- When no plausible stress read exists, say so and move to the next unresolved
+  decision.
 - Distinguish an ungrillable question from an unresolved one. Recommend a
   concrete experiment when reaction to evidence, behavior, or a prototype is
   required.
@@ -100,8 +101,8 @@ to triangulate.
 ## Continue and stop
 
 After the user answers, recompute the faithful, steel, and stress reads from the
-new evidence; do not defend the previous convergence. Continue until one of
-these conditions holds:
+new evidence and treat the previous convergence as provisional. Continue until
+one of these conditions holds:
 
 - the user explicitly accepts a formulation and no material crux remains;
 - the remaining difference is an acknowledged value choice;
@@ -109,5 +110,5 @@ these conditions holds:
 - the user stops or changes the task.
 
 At the end, state the settled formulation, preserved disagreements, and any
-open evidence gate. Do not turn the result into a plan or act on it unless the
-user asks.
+open evidence gate. Wait for the user's explicit request before planning or
+acting on the result.

--- a/skills/triangulate-me/references/interaction-examples.md
+++ b/skills/triangulate-me/references/interaction-examples.md
@@ -31,10 +31,10 @@ User answer:
 
 > MongoDB should replace Postgres because our writes are slow.
 
-Do not synthesize a database choice from competing rhetoric. Preserve the claim
-as a hypothesis, name the absent measurement, and ask for or perform the next
-diagnostic check. A valid convergence can be: "Treat datastore replacement as
-unproven until the write bottleneck is localized."
+Preserve the database choice as a hypothesis, name the absent measurement, and
+ask for or perform the next diagnostic check. A valid convergence can be:
+"Treat datastore replacement as unproven until the write bottleneck is
+localized."
 
 ## Fixed constraint with a borrowed solution
 
@@ -70,11 +70,11 @@ User answer:
 
 > Anonymous use protects privacy, but removing it would reduce abuse.
 
-Differentiate the values and do not pretend evidence alone chooses their
-priority. A convergence may define a reversible boundary—such as anonymous
-reading with rate-limited or verified high-impact actions—only if it follows
-from the stated product context. Otherwise preserve the privacy-versus-abuse
-choice and ask which actions create unacceptable harm.
+Differentiate the values and leave their priority with the user. A convergence
+may define a reversible boundary—such as anonymous reading with rate-limited or
+verified high-impact actions—only if it follows from the stated product context.
+Otherwise preserve the privacy-versus-abuse choice and ask which actions create
+unacceptable harm.
 
 ## No plausible stress read
 
@@ -83,9 +83,8 @@ User answer:
 > Every production migration needs a named owner, a tested rollback, and an
 > observable success condition.
 
-Do not invent a foolish objection. State that the answer is already bounded and
-testable, note any genuinely missing scope only if relevant, and move to the
-next unresolved decision.
+State that the answer is already bounded and testable, note any genuinely
+missing scope only if relevant, and move to the next unresolved decision.
 
 ## No substantive answer
 
@@ -93,5 +92,5 @@ User answer:
 
 > Thanks, that makes sense.
 
-Do not emit six interpretation headings. Acknowledge normally. Continue only if
-the prior inquiry still has an unresolved question.
+Acknowledge normally. Continue only if the prior inquiry still has an unresolved
+question.

--- a/skills/triangulate-me/references/reasoning-foundations.md
+++ b/skills/triangulate-me/references/reasoning-foundations.md
@@ -85,15 +85,3 @@ claim true merely because it lies between them.
 - Operational rule: allow convergence to endorse one side, revise both sides,
   preserve disagreement, or abstain.
 - Limit: balanced presentation does not imply equal evidential weight.
-
-## Derived quality test
-
-A strong triangulation should pass all of these checks:
-
-1. Could the user recognize the faithful read as their actual commitment?
-2. Does the steel read improve coherence without silently changing the claim?
-3. Could a reasonable critic honestly make the stress read from the available
-   language or evidence?
-4. Does the crux explain the difference rather than merely rename it?
-5. Does the convergence say what changed and avoid automatic compromise?
-6. Does the next question resolve the crux rather than open an unrelated branch?


### PR DESCRIPTION
## What changed

- update the README for the current Tink refresh and library workflow
- give Triangulate Me checkable completion criteria, positive steering, and a leaner single source of truth
- clarify that Skill Scout's `ABSTAIN/BUILD` is an outcome and preserve existing online-search authorization

## Why

The published guidance contained one obsolete Tink option, duplicated Triangulate Me quality rules, and two ambiguous Skill Scout decision boundaries. These changes make the instructions more predictable without changing the underlying workflows or expanding their machinery.

## Validation

- 18 promotion-tool tests
- 105 skill-eval-loop tests
- Ruff
- Triangulate Me evaluation audit: 4 cases / 4 provenance records
- Skill Scout evaluation audit: 9 cases / 9 provenance records
- installer discovery
- README link check: 8 links
- `git diff --check`

No paid model evaluation was run; the evaluation audits prove suite integrity, not behavioral equivalence.