### PR TITLE
Improve triangulate-me behavioral reliability

### DIFF
--- a/skills/skill-eval-loop/SKILL.md
+++ b/skills/skill-eval-loop/SKILL.md
@@ -138,6 +138,10 @@ collect exact ids from its model picker and rerun with
 `--models exact-id-1,exact-id-2`. Availability, price, and quota come only from
 live discovery or the user — invent none.
 
+Pin the identity exactly as the selected harness reports it. Attestation
+normalizes surrounding whitespace and case only: provider-qualified and bare
+model ids are distinct, and no provider or model aliases are inferred.
+
 Show the budget, balanced, and quality frontier; disclose tier fallbacks and
 unknown cost. For a release claim, prefer the intended deployment model. For
 portability, plan separate runs across tiers. Use no judge when the suite is

--- a/skills/skill-eval-loop/SKILL.md
+++ b/skills/skill-eval-loop/SKILL.md
@@ -21,7 +21,9 @@ Require:
 - a target directory containing `SKILL.md`;
 - an existing `evals/evals.json`, a supplied `--evals-path`, or authority to
   launch a fresh subagent to author the suite;
-- references that pass every declared grader;
+- references that pass every declared grader; use schema-3 `case_contrast` when
+  the result must claim every response-sensitive grader distinguishes a known
+  good/bad pair;
 - an exact model identifier before live trials;
 - a working executable and authentication for the selected harness;
 - a Herdr-managed pane with `HERDR_ENV=1` only for `--observer herdr`.
@@ -224,12 +226,14 @@ toolset, or sandbox-only — recorded in the run artifact). Prefer deterministic
 graders.
 
 The runner owns counterbalance (odd trials control-first; even trials
-treatment-first), reference validation, provenance hashes, and post-invocation
-trace-attested model identity checks. A missing or mismatched judge identity
-stops on the first reference judge; without model rubrics, a missing or
-mismatched target identity stops after the first target invocation. Forced Codex
-treatment also requires trace-visible access to the full structured skill
-payload before downstream grading.
+treatment-first), per-grader contrast validation, provenance hashes, and
+post-invocation trace-attested model identity checks. A missing or mismatched
+judge identity stops on the first reference judge; in a `case_contrast` suite,
+a model grader that accepts the declared bad response stops before target
+trials. Without model rubrics, a missing or mismatched target identity stops
+after the first target invocation.
+Forced Codex treatment also requires trace-visible access to the full structured
+skill payload before downstream grading.
 
 Raw harness traces are the evidence owner. Herdr, when enabled, focuses a
 retained workspace once, reuses condition panes sequentially, and routes model-

--- a/skills/skill-eval-loop/references/eval-authoring.md
+++ b/skills/skill-eval-loop/references/eval-authoring.md
@@ -45,8 +45,10 @@ Require all of the following:
 - deterministic final-state graders where feasible, with unique behavioral
   names; use model rubrics only for qualities that cannot be checked
   deterministically;
-- minimal fixtures and references that pass every declared grader without
-  depending on the candidate run;
+- minimal fixtures and references that pass every declared grader; for a
+  release-grade discrimination claim, declare schema-3 `case_contrast` and
+  provide a good/bad response pair that every response-sensitive grader
+  distinguishes without depending on the candidate run;
 - honest provenance: use `author_derived` and `author_scenario` for newly
   invented cases, never label them `held_out` or `production_regression`;
 - one retained source artifact and valid suite, case, and artifact hashes for

--- a/skills/skill-eval-loop/references/eval-suite-schema.md
+++ b/skills/skill-eval-loop/references/eval-suite-schema.md
@@ -17,6 +17,7 @@ each case to retained provenance.
   "dataset_origin": "author_derived",
   "tool_profile": "no_tools",
   "activation_mode": "forced",
+  "grader_discrimination": "case_contrast",
   "provenance_manifest": "provenance.json",
   "distribution_policy": {
     "minimum_pairs": 3,
@@ -41,26 +42,35 @@ Use:
 - `forced` to expand the target skill before the task, or `autonomous` to
   expose only its metadata and measure whether the model reads `SKILL.md`.
 
-Each case may declare an optional `counter_reference` beside `reference`:
+Each case may declare a `counter_reference` beside `reference`:
 
 ```json
 "reference": {"response": "a correct answer"},
 "counter_reference": {"response": "a plausible but wrong answer"}
 ```
 
-`reference` proves the graders accept a correct answer. `counter_reference`
-proves they reject a wrong one. Both are graded before any trial runs, and a
-counter-reference that passes stops the run: graders that accept everything
-report the same verdict for both conditions, so the paired comparison says
-nothing. A counter-reference is part of the case, so adding one changes the case
-hash and the provenance manifest needs re-registering.
+By itself, an optional counter is only an aggregate canary: it proves at least
+one grader rejects the wrong answer. A schema-version-3 suite may make the
+stronger claim with `"grader_discrimination": "case_contrast"`. Then every case
+with a response-sensitive grader must provide a counter, the static audit proves
+each deterministic response grader accepts the correct answer and rejects the
+wrong one, and each `model_rubric` must do the same through the selected judge
+harness before target trials. Aggregation checks the retained per-grader results
+again; one permissive grader cannot hide behind another grader's rejection.
 
-`counter_reference` must include a string `response` (empty objects are
-rejected). It is only valid when the case has at least one response-sensitive
-grader (`response_contains`, `response_not_contains`, `response_regex`,
-`markdown_table_column_regex`, or `model_rubric`). The canary grades the wrong
-response on the gold `reference` workspace, so `file_exists` / `json_exact`
-alone cannot discriminate and are rejected at load.
+Omitting `grader_discrimination` is equivalent to `"none"` and preserves the
+legacy aggregate canary. A counter-reference is part of the case, so adding or
+changing one changes the case hash and the provenance manifest needs
+re-registering.
+
+Under `case_contrast`, the correct and wrong responses must be non-empty and
+distinct. `counter_reference` is only valid when the case has at least one
+response-sensitive grader (`response_contains`, `response_not_contains`,
+`response_regex`, `markdown_table_column_regex`, or `model_rubric`). The
+contrast grades the wrong response on the gold `reference` workspace, so
+`file_exists` / `json_exact` alone cannot discriminate and are rejected at
+load. Schema version 2 keeps its optional counter for compatibility and cannot
+declare `case_contrast`.
 
 Every condition receives the same task, fixture, model, harness, and tool
 profile. The treatment additionally receives the selected harness's native
@@ -161,6 +171,7 @@ Use at least three meaningfully different cases, not paraphrases. Include a
 positive case and, where the skill has a real boundary, edge or negative cases.
 Prompts should resemble ordinary user requests and must not name the skill,
 quote its instructions, or expose its internal layout. Prefer deterministic,
-behavior-focused graders and references that pass those graders. Record newly
+behavior-focused graders and good/bad contrasts that every response grader
+distinguishes when the suite will support a grader-discrimination claim. Record newly
 invented cases honestly as `author_derived`; independence of the authoring
 subagent does not make a case statistically held out.

--- a/skills/skill-eval-loop/references/interpret-benchmark.md
+++ b/skills/skill-eval-loop/references/interpret-benchmark.md
@@ -17,6 +17,9 @@ run. Report only local paired evidence.
 - `task_success.delta` — treatment rate minus control rate.
 - `selection_verdict` and `routing.accuracy` — trace-visible access only, for
   autonomous schema-3 suites.
+- `grader_discrimination` — `case_contrast` is validated only when every
+  response-sensitive grader accepted the declared good response and rejected
+  the bad one; `none` means optional counters were only aggregate canaries.
 - `routing` — treatment availability, trace-visible injection, explicit access,
   selection errors, and control exposure.
 - `operations.without_skill` and `operations.with_skill` — target-condition

--- a/skills/skill-eval-loop/scripts/aggregate_benchmark.py
+++ b/skills/skill-eval-loop/scripts/aggregate_benchmark.py
@@ -10,7 +10,7 @@ import re
 import sys
 from pathlib import Path
 
-from eval_spec import harness_invocation_counts
+from eval_spec import RESPONSE_SENSITIVE_GRADER_TYPES, harness_invocation_counts
 from runtime_adapters import (
     HARNESS_NAMES,
     model_matches,
@@ -123,6 +123,48 @@ def _load_grading(path: Path, label: str) -> tuple[dict, bool]:
         json.loads(path.read_text(encoding="utf-8")),
         label,
     )
+
+
+def _validate_response_grader_outcomes(
+    grading: dict,
+    *,
+    expected: dict[str, str],
+    expected_passed: bool,
+    label: str,
+) -> None:
+    observed = {
+        (expectation.get("text"), expectation.get("grader"))
+        for expectation in grading["expectations"]
+        if expectation.get("grader") in RESPONSE_SENSITIVE_GRADER_TYPES
+    }
+    declared = set(expected.items())
+    if observed != declared:
+        raise ValueError(
+            f"{label} does not retain the declared response-sensitive "
+            "grader outcomes"
+        )
+    wrong_verdicts = [
+        name
+        for name in expected
+        if next(
+            expectation
+            for expectation in grading["expectations"]
+            if expectation.get("text") == name
+        )["passed"]
+        is not expected_passed
+    ]
+    if wrong_verdicts:
+        if expected_passed:
+            raise ValueError(
+                f"{label} must pass every declared response-sensitive "
+                "grader: "
+                + ", ".join(wrong_verdicts)
+            )
+        raise ValueError(
+            f"{label} counter_reference did not fail response-sensitive "
+            "graders: "
+            + ", ".join(wrong_verdicts)
+        )
 
 
 def _judge_identity_valid(
@@ -316,6 +358,9 @@ def aggregate(run_dir: Path) -> dict:
     if _sha256_file(suite_path) != manifest.get("suite_sha256"):
         raise ValueError("manifest.suite_sha256 does not match suite snapshot")
     suite_snapshot = json.loads(suite_path.read_text(encoding="utf-8"))
+    grader_discrimination = suite_snapshot.get("grader_discrimination", "none")
+    if grader_discrimination not in {"none", "case_contrast"}:
+        raise ValueError("suite snapshot grader_discrimination is invalid")
     cases = suite_snapshot.get("cases")
     if not isinstance(cases, list) or not cases:
         raise ValueError("suite snapshot must contain cases")
@@ -345,6 +390,55 @@ def aggregate(run_dir: Path) -> dict:
             "suite snapshot accounting metadata must be complete and valid for every case"
         )
     accounting_available = all(accounting_fields_valid)
+    response_graders_by_case: dict[str, dict[str, str]] = {}
+    if grader_discrimination == "case_contrast":
+        if not accounting_available:
+            raise ValueError(
+                "case_contrast requires complete per-case accounting metadata"
+            )
+        for case_index, case in enumerate(cases, start=1):
+            label = f"suite snapshot cases[{case_index}]"
+            declared_graders = case.get("response_sensitive_graders")
+            if not isinstance(declared_graders, list):
+                raise ValueError(
+                    f"{label}.response_sensitive_graders must be a list"
+                )
+            by_name: dict[str, str] = {}
+            for grader_index, grader in enumerate(declared_graders, start=1):
+                grader_label = (
+                    f"{label}.response_sensitive_graders[{grader_index}]"
+                )
+                if not isinstance(grader, dict):
+                    raise ValueError(f"{grader_label} must be an object")
+                name = grader.get("name")
+                grader_type = grader.get("type")
+                if not isinstance(name, str) or not name or name in by_name:
+                    raise ValueError(
+                        f"{grader_label}.name is missing or duplicate"
+                    )
+                if grader_type not in RESPONSE_SENSITIVE_GRADER_TYPES:
+                    raise ValueError(
+                        f"{grader_label}.type is not response-sensitive"
+                    )
+                by_name[name] = grader_type
+            if sum(
+                grader_type == "model_rubric"
+                for grader_type in by_name.values()
+            ) != case["model_rubric_count"]:
+                raise ValueError(
+                    f"{label}.response_sensitive_graders does not match "
+                    "model_rubric_count"
+                )
+            if case["counter_reference_declared"] != bool(by_name):
+                raise ValueError(
+                    f"{label}.counter_reference_declared must match "
+                    "response-sensitive graders"
+                )
+            response_graders_by_case[str(case["id"])] = by_name
+        if not any(response_graders_by_case.values()):
+            raise ValueError(
+                "case_contrast requires at least one response-sensitive grader"
+            )
     trials_per_case = manifest.get("trials_per_case")
     if type(trials_per_case) is not int or trials_per_case < 1:
         raise ValueError("manifest.trials_per_case must be a positive integer")
@@ -433,6 +527,16 @@ def aggregate(run_dir: Path) -> dict:
                     f"manifest.reference_validation[{ref_index}].grading "
                     "does not pass all graders"
                 )
+            if grader_discrimination == "case_contrast":
+                reference_grading = reference["grading"]
+                _validate_response_grader_outcomes(
+                    reference_grading,
+                    expected=response_graders_by_case[reference_case_id],
+                    expected_passed=True,
+                    label=(
+                        f"manifest.reference_validation[{ref_index}].grading"
+                    ),
+                )
         if counter is not None:
             if not isinstance(counter, dict):
                 raise ValueError(
@@ -443,7 +547,7 @@ def aggregate(run_dir: Path) -> dict:
                 ("counter_reference.judge_records", counter_reference_judges),
             )
             if accounting_available:
-                _, counter_passed = _validate_grading(
+                counter_grading, counter_passed = _validate_grading(
                     counter.get("grading"),
                     f"manifest.reference_validation[{ref_index}]"
                     ".counter_reference.grading",
@@ -452,6 +556,16 @@ def aggregate(run_dir: Path) -> dict:
                     raise ValueError(
                         f"manifest.reference_validation[{ref_index}]"
                         ".counter_reference passed all graders"
+                    )
+                if grader_discrimination == "case_contrast":
+                    _validate_response_grader_outcomes(
+                        counter_grading,
+                        expected=response_graders_by_case[reference_case_id],
+                        expected_passed=False,
+                        label=(
+                            f"manifest.reference_validation[{ref_index}]"
+                            ".counter_reference.grading"
+                        ),
                     )
         for key, retained in judge_groups:
             records = (
@@ -778,6 +892,10 @@ def aggregate(run_dir: Path) -> dict:
         "mechanism_valid": mechanism_valid,
         "runtime_attestation_complete": not runtime_attestation_gaps,
         "activation_mode": activation_mode,
+        "grader_discrimination": {
+            "claim": grader_discrimination,
+            "validated": grader_discrimination == "case_contrast",
+        },
         "selection_verdict": (
             "passed"
             if routing_accuracy == 1.0
@@ -812,6 +930,15 @@ def aggregate(run_dir: Path) -> dict:
         "operations": operations,
         "limits": [
             "This is a local paired diagnostic, not a distribution or significance claim.",
+            *(
+                [
+                    "The suite did not declare grader_discrimination=case_contrast; "
+                    "optional counters do not prove every response-sensitive grader "
+                    "distinguishes a known good/bad pair."
+                ]
+                if grader_discrimination == "none"
+                else []
+            ),
             *(
                 [
                     "distribution_policy was declared by the suite and not applied to this "

--- a/skills/skill-eval-loop/scripts/audit_suite.py
+++ b/skills/skill-eval-loop/scripts/audit_suite.py
@@ -12,6 +12,9 @@ from eval_spec import load_suite
 
 def _error_code(message: str) -> str:
     rules = (
+        ("counter_reference is required", "missing_grader_contrast"),
+        ("grader contrast", "non_discriminating_grader_contrast"),
+        ("counter_reference", "invalid_grader_contrast"),
         ("artifact_sha256 does not match artifact", "provenance_hash_mismatch"),
         ("case_sha256 does not match eval case", "provenance_case_mismatch"),
         ("suite_sha256 does not match eval suite", "provenance_suite_mismatch"),
@@ -32,9 +35,11 @@ def audit(skill_path: Path, evals_path: Path | None = None) -> dict:
     try:
         suite = load_suite(skill_path, evals_path)
     except (OSError, ValueError, KeyError, json.JSONDecodeError) as exc:
+        message = str(exc)
         return {
             "valid": False,
-            "errors": [_error_code(str(exc))],
+            "errors": [_error_code(message)],
+            "details": [message],
         }
     routing_classes = sorted(
         {
@@ -43,6 +48,30 @@ def audit(skill_path: Path, evals_path: Path | None = None) -> dict:
             if case.get("routing_class")
         }
     )
+    discrimination = {
+        "claim": suite["grader_discrimination"],
+        "contrast_case_count": sum(
+            suite["grader_discrimination"] == "case_contrast"
+            and case.get("counter_reference") is not None
+            and case["grader_discrimination"][
+                "response_sensitive_grader_count"
+            ]
+            > 0
+            for case in suite["evals"]
+        ),
+        "response_sensitive_grader_count": sum(
+            case["grader_discrimination"]["response_sensitive_grader_count"]
+            for case in suite["evals"]
+        ),
+        "deterministic_graders_checked": sum(
+            case["grader_discrimination"]["deterministic_graders_checked"]
+            for case in suite["evals"]
+        ),
+        "model_graders_pending_runtime": sum(
+            case["grader_discrimination"]["model_graders_pending_runtime"]
+            for case in suite["evals"]
+        ),
+    }
     return {
         "valid": True,
         "errors": [],
@@ -53,6 +82,7 @@ def audit(skill_path: Path, evals_path: Path | None = None) -> dict:
         "activation_mode": suite["activation_mode"],
         "case_count": len(suite["evals"]),
         "routing_classes": routing_classes,
+        "grader_discrimination": discrimination,
         "distribution_policy": suite.get("distribution_policy"),
         "provenance_case_count": len(suite.get("provenance_records", {})),
     }

--- a/skills/skill-eval-loop/scripts/eval_spec.py
+++ b/skills/skill-eval-loop/scripts/eval_spec.py
@@ -31,6 +31,9 @@ RESPONSE_SENSITIVE_GRADER_TYPES = frozenset(
         "model_rubric",
     }
 )
+DETERMINISTIC_RESPONSE_GRADER_TYPES = (
+    RESPONSE_SENSITIVE_GRADER_TYPES - {"model_rubric"}
+)
 SKILL_LOADING_POLICIES = {"required", "optional", "forbidden"}
 SUITE_TYPES = {"capability", "regression"}
 DATASET_ORIGINS = {"author_derived", "held_out", "production_regression"}
@@ -45,6 +48,7 @@ BEHAVIOR_CLASSES = {"positive", "edge", "negative"}
 ROUTING_CLASSES = {"should_trigger", "should_not_trigger", "ambiguous"}
 TOOL_PROFILES = {"no_tools", "read_only", "read_write", "coding"}
 ACTIVATION_MODES = {"forced", "autonomous"}
+GRADER_DISCRIMINATION_CLAIMS = {"none", "case_contrast"}
 
 
 def canonical_sha256(value: object) -> str:
@@ -311,6 +315,72 @@ def _validate_grader(grader: object, case_label: str, index: int) -> dict[str, A
     return normalized
 
 
+def _validate_response_contrast(
+    *,
+    case_label: str,
+    reference: dict[str, Any],
+    counter_reference: dict[str, Any],
+    graders: list[dict[str, Any]],
+) -> dict[str, int]:
+    """Validate the offline portion of one explicit good/bad contrast."""
+    reference_response = reference.get("response", "")
+    counter_response = counter_reference["response"]
+    if not reference_response.strip():
+        raise ValueError(
+            f"{case_label}.reference.response must be non-empty for a "
+            "grader contrast"
+        )
+    if not counter_response.strip():
+        raise ValueError(
+            f"{case_label}.counter_reference.response must be non-empty for "
+            "a grader contrast"
+        )
+    if reference_response.strip() == counter_response.strip():
+        raise ValueError(
+            f"{case_label}.counter_reference.response must differ from "
+            "reference.response for a grader contrast"
+        )
+
+    response_graders = [
+        grader
+        for grader in graders
+        if grader["type"] in RESPONSE_SENSITIVE_GRADER_TYPES
+    ]
+    deterministic_graders = [
+        grader
+        for grader in response_graders
+        if grader["type"] in DETERMINISTIC_RESPONSE_GRADER_TYPES
+    ]
+    for grader in deterministic_graders:
+        reference_grading = grade_case(
+            workspace=Path(),
+            response=reference_response,
+            graders=[grader],
+        )
+        if not reference_grading["expectations"][0]["passed"]:
+            raise ValueError(
+                f"{case_label} grader contrast reference does not pass "
+                f"grader {grader['name']!r}"
+            )
+        counter_grading = grade_case(
+            workspace=Path(),
+            response=counter_response,
+            graders=[grader],
+        )
+        if counter_grading["expectations"][0]["passed"]:
+            raise ValueError(
+                f"{case_label} grader contrast counter_reference does not "
+                f"fail grader {grader['name']!r}"
+            )
+    return {
+        "response_sensitive_grader_count": len(response_graders),
+        "deterministic_graders_checked": len(deterministic_graders),
+        "model_graders_pending_runtime": sum(
+            grader["type"] == "model_rubric" for grader in response_graders
+        ),
+    }
+
+
 def load_suite(skill_path: Path, evals_path: Path | None = None) -> dict[str, Any]:
     skill_path = skill_path.resolve()
     source = (evals_path or skill_path / "evals" / "evals.json").resolve()
@@ -339,6 +409,17 @@ def load_suite(skill_path: Path, evals_path: Path | None = None) -> dict[str, An
     if activation_mode == "autonomous" and schema_version != 3:
         raise ValueError(
             f"{source}.activation_mode=autonomous requires schema_version 3"
+        )
+    grader_discrimination = data.get("grader_discrimination", "none")
+    if grader_discrimination not in GRADER_DISCRIMINATION_CLAIMS:
+        raise ValueError(
+            f"{source}.grader_discrimination must be one of "
+            f"{sorted(GRADER_DISCRIMINATION_CLAIMS)}"
+        )
+    if grader_discrimination != "none" and schema_version != 3:
+        raise ValueError(
+            f"{source}.grader_discrimination={grader_discrimination} "
+            "requires schema_version 3"
         )
     if data.get("skill_name") != skill_path.name:
         raise ValueError(
@@ -425,6 +506,20 @@ def load_suite(skill_path: Path, evals_path: Path | None = None) -> dict[str, An
         grader_names = [grader["name"] for grader in normalized["graders"]]
         if len(grader_names) != len(set(grader_names)):
             raise ValueError(f"{label} has a duplicate grader name")
+        response_sensitive_graders = [
+            grader
+            for grader in normalized["graders"]
+            if grader["type"] in RESPONSE_SENSITIVE_GRADER_TYPES
+        ]
+        if (
+            grader_discrimination == "case_contrast"
+            and response_sensitive_graders
+            and counter_reference is None
+        ):
+            raise ValueError(
+                f"{label}.counter_reference is required when "
+                "grader_discrimination=case_contrast"
+            )
         if counter_reference is not None and not any(
             grader["type"] in RESPONSE_SENSITIVE_GRADER_TYPES
             for grader in normalized["graders"]
@@ -436,6 +531,23 @@ def load_suite(skill_path: Path, evals_path: Path | None = None) -> dict[str, An
                 "file_exists/json_exact alone cannot discriminate a wrong "
                 "response on the gold reference workspace"
             )
+        normalized["grader_discrimination"] = (
+            _validate_response_contrast(
+                case_label=label,
+                reference=reference,
+                counter_reference=counter_reference,
+                graders=normalized["graders"],
+            )
+            if counter_reference is not None
+            and grader_discrimination == "case_contrast"
+            else {
+                "response_sensitive_grader_count": len(
+                    response_sensitive_graders
+                ),
+                "deterministic_graders_checked": 0,
+                "model_graders_pending_runtime": 0,
+            }
+        )
         if schema_version == 2:
             for grader_index, grader in enumerate(
                 normalized["graders"],
@@ -495,6 +607,14 @@ def load_suite(skill_path: Path, evals_path: Path | None = None) -> dict[str, An
                     + "\n- ".join(requirements)
                 )
         normalized_cases.append(normalized)
+    if grader_discrimination == "case_contrast" and not any(
+        case["grader_discrimination"]["response_sensitive_grader_count"]
+        for case in normalized_cases
+    ):
+        raise ValueError(
+            f"{source} grader contrast requires at least one "
+            "response-sensitive grader"
+        )
     suite_root = source.parent if schema_version == 3 else skill_path
     distribution_policy = None
     provenance_records: dict[str, Any] = {}
@@ -520,6 +640,7 @@ def load_suite(skill_path: Path, evals_path: Path | None = None) -> dict[str, An
     return {
         **data,
         "activation_mode": activation_mode,
+        "grader_discrimination": grader_discrimination,
         "source_path": str(source),
         "suite_root": str(suite_root),
         "distribution_policy": distribution_policy,

--- a/skills/skill-eval-loop/scripts/run_skill_eval.py
+++ b/skills/skill-eval-loop/scripts/run_skill_eval.py
@@ -22,6 +22,7 @@ from eval_runtime import (
     start_eval_run,
 )
 from eval_spec import (
+    RESPONSE_SENSITIVE_GRADER_TYPES,
     canonical_sha256,
     grade_case,
     harness_invocation_counts,
@@ -244,14 +245,27 @@ def _validate_references(
             judge_timeout_seconds=judge_timeout_seconds,
             eval_run=eval_run,
         )
-        if (
-            counter_grading is not None
-            and not counter_grading["grading"]["summary"]["failed"]
-        ):
-            raise ValueError(
-                f"counter-reference passed graders for case {case['id']}; "
-                "the graders do not separate a correct answer from a wrong one"
-            )
+        if counter_grading is not None:
+            if suite["grader_discrimination"] == "case_contrast":
+                non_discriminating = [
+                    expectation["text"]
+                    for expectation in counter_grading["grading"]["expectations"]
+                    if expectation["grader"] in RESPONSE_SENSITIVE_GRADER_TYPES
+                    and expectation["passed"]
+                ]
+                if non_discriminating:
+                    raise ValueError(
+                        "counter-reference did not fail response-sensitive "
+                        "graders: "
+                        + ", ".join(non_discriminating)
+                        + f"; case {case['id']} does not prove grader "
+                        "discrimination"
+                    )
+            elif not counter_grading["grading"]["summary"]["failed"]:
+                raise ValueError(
+                    f"counter-reference passed graders for case {case['id']}; "
+                    "the graders do not separate a correct answer from a wrong one"
+                )
         record = {
             "case_id": case["id"],
             "valid": True,
@@ -645,6 +659,7 @@ def run_suite(
             "dataset_origin": suite["dataset_origin"],
             "tool_profile": suite["tool_profile"],
             "activation_mode": suite["activation_mode"],
+            "grader_discrimination": suite["grader_discrimination"],
             "distribution_policy": suite.get("distribution_policy"),
             "source_sha256": _sha256_file(Path(suite["source_path"])),
             "cases": [
@@ -657,6 +672,11 @@ def run_suite(
                         grader["type"] == "model_rubric"
                         for grader in case["graders"]
                     ),
+                    "response_sensitive_graders": [
+                        {"name": grader["name"], "type": grader["type"]}
+                        for grader in case["graders"]
+                        if grader["type"] in RESPONSE_SENSITIVE_GRADER_TYPES
+                    ],
                     "counter_reference_declared": (
                         case.get("counter_reference") is not None
                     ),

--- a/skills/skill-eval-loop/scripts/runtime_adapters.py
+++ b/skills/skill-eval-loop/scripts/runtime_adapters.py
@@ -63,6 +63,22 @@ def model_matches(requested: str, actual: object) -> bool:
     return bool(requested_identity) and requested_identity == actual_identity
 
 
+def _record_model_identities(record: dict[str, Any]) -> list[str]:
+    model = record.get("model")
+    if not isinstance(model, str) or not model.strip():
+        return []
+    model = model.strip()
+    provider = record.get("provider")
+    if not isinstance(provider, str) or not provider.strip():
+        return [model]
+    provider = provider.strip()
+    if "/" not in model:
+        return [f"{provider}/{model}"]
+    if model.split("/", 1)[0].lower() == provider.lower():
+        return [model]
+    return [model, f"{provider}/{model}"]
+
+
 def resolve_harness(
     harness: str,
     executable: str | None = None,
@@ -557,12 +573,11 @@ def trace_metadata(
             and event.get("subtype") == "init"
             and isinstance(event.get("model"), str)
         ):
-            models.append(event["model"])
+            models.extend(_record_model_identities(event))
         for message in _messages(event):
             if message.get("role") != "assistant":
                 continue
-            if isinstance(message.get("model"), str):
-                models.append(message["model"])
+            models.extend(_record_model_identities(message))
             response = _message_text(message)
             if response and (not responses or responses[-1] != response):
                 responses.append(response)
@@ -638,7 +653,7 @@ def trace_metadata(
                     event.get("type") == "turn_context"
                     and isinstance(payload.get("model"), str)
                 ):
-                    models.append(payload["model"])
+                    models.extend(_record_model_identities(payload))
                 if skill_name and event.get("type") == "world_state":
                     state = payload.get("state")
                     host_skills = (
@@ -699,7 +714,7 @@ def trace_metadata(
             usage_report = None
         if isinstance(usage_report, dict):
             if isinstance(usage_report.get("model"), str):
-                models.append(usage_report["model"])
+                models.extend(_record_model_identities(usage_report))
             if isinstance(usage_report.get("session_id"), str):
                 session_ids.append(usage_report["session_id"])
             usage_records.append(usage_report)

--- a/skills/skill-eval-loop/scripts/runtime_adapters.py
+++ b/skills/skill-eval-loop/scripts/runtime_adapters.py
@@ -51,12 +51,16 @@ def validate_pinned_model(model: str) -> None:
         raise ValueError("use an exact pinned model id, not a moving alias")
 
 
+def _normalized_model_identity(model: object) -> str:
+    if not isinstance(model, str):
+        return ""
+    return model.strip().lower()
+
+
 def model_matches(requested: str, actual: object) -> bool:
-    if not isinstance(actual, str) or not actual:
-        return False
-    requested_leaf = requested.rsplit("/", 1)[-1].lower()
-    actual_leaf = actual.rsplit("/", 1)[-1].lower()
-    return requested_leaf == actual_leaf
+    requested_identity = _normalized_model_identity(requested)
+    actual_identity = _normalized_model_identity(actual)
+    return bool(requested_identity) and requested_identity == actual_identity
 
 
 def resolve_harness(
@@ -704,9 +708,9 @@ def trace_metadata(
         responses.append(raw_trace.strip())
     usage = usage_records[-1] if usage_records else {}
     model_identities = {
-        model.rsplit("/", 1)[-1].lower()
+        identity
         for model in models
-        if model.strip()
+        if (identity := _normalized_model_identity(model))
     }
     model_attestation_conflict = len(model_identities) > 1
     actual_model = (

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -1537,6 +1537,61 @@ class RuntimeTests(unittest.TestCase):
             self.assertFalse(metadata["model_attested"])
             self.assertTrue(metadata["model_attestation_conflict"])
 
+    def test_pi_trace_combines_separate_provider_and_model_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            trace = Path(temp) / "trace.jsonl"
+            trace.write_text(
+                json.dumps(
+                    {
+                        "type": "message_start",
+                        "message": {
+                            "role": "assistant",
+                            "provider": "openai-codex",
+                            "model": "gpt-5.6-sol",
+                            "content": [],
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            metadata = trace_metadata(trace, "", harness="pi")
+            self.assertEqual(metadata["actual_model"], "openai-codex/gpt-5.6-sol")
+            self.assertTrue(metadata["model_attested"])
+            self.assertFalse(metadata["model_attestation_conflict"])
+            self.assertTrue(
+                model_matches(
+                    "openai-codex/gpt-5.6-sol",
+                    metadata["actual_model"],
+                )
+            )
+
+    def test_pi_trace_conflicting_separate_providers_fail_attestation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            trace = Path(temp) / "trace.jsonl"
+            trace.write_text(
+                "\n".join(
+                    json.dumps(
+                        {
+                            "type": "message_start",
+                            "message": {
+                                "role": "assistant",
+                                "provider": provider,
+                                "model": "model-1",
+                                "content": [],
+                            },
+                        }
+                    )
+                    for provider in ("provider-a", "provider-b")
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            metadata = trace_metadata(trace, "", harness="pi")
+            self.assertEqual(metadata["actual_model"], "")
+            self.assertFalse(metadata["model_attested"])
+            self.assertTrue(metadata["model_attestation_conflict"])
+
     def test_codex_skill_catalog_with_description_attests_injection(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -500,6 +500,7 @@ def _make_schema3_skill(root: Path, *, tamper: bool = False) -> Path:
             }
         ],
         "reference": {"response": "done"},
+        "counter_reference": {"response": "wrong"},
     }
     suite = {
         "schema_version": 3,
@@ -507,6 +508,7 @@ def _make_schema3_skill(root: Path, *, tamper: bool = False) -> Path:
         "suite_type": "regression",
         "dataset_origin": "author_derived",
         "tool_profile": "no_tools",
+        "grader_discrimination": "case_contrast",
         "provenance_manifest": "provenance.json",
         "distribution_policy": {
             "minimum_pairs": 3,
@@ -547,6 +549,97 @@ class SuiteAuditTests(unittest.TestCase):
             report = audit(_make_schema3_skill(Path(temp)))
             self.assertTrue(report["valid"])
             self.assertEqual(report["provenance_case_count"], 1)
+            self.assertEqual(
+                report["grader_discrimination"],
+                {
+                    "claim": "case_contrast",
+                    "contrast_case_count": 1,
+                    "response_sensitive_grader_count": 1,
+                    "deterministic_graders_checked": 1,
+                    "model_graders_pending_runtime": 0,
+                },
+            )
+
+    def test_missing_schema_three_contrast_fails_with_actionable_code(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            skill = _make_schema3_skill(Path(temp))
+            suite_path = skill / "evals" / "evals.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            suite["evals"][0].pop("counter_reference")
+            _write_json(suite_path, suite)
+            report = audit(skill)
+            self.assertFalse(report["valid"])
+            self.assertEqual(report["errors"], ["missing_grader_contrast"])
+
+    def test_non_discriminating_contrast_fails_with_actionable_code(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            skill = _make_schema3_skill(Path(temp))
+            suite_path = skill / "evals" / "evals.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            suite["evals"][0]["counter_reference"] = {"response": "done"}
+            _write_json(suite_path, suite)
+            report = audit(skill)
+            self.assertFalse(report["valid"])
+            self.assertEqual(
+                report["errors"],
+                ["non_discriminating_grader_contrast"],
+            )
+
+    def test_contrast_claim_with_only_workspace_graders_fails_audit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            skill = _make_schema3_skill(Path(temp))
+            suite_path = skill / "evals" / "evals.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            suite["evals"][0]["graders"] = [
+                {
+                    "name": "Creates the result",
+                    "type": "file_exists",
+                    "path": "result.json",
+                }
+            ]
+            suite["evals"][0].pop("counter_reference")
+            _write_json(suite_path, suite)
+            report = audit(skill)
+            self.assertFalse(report["valid"])
+            self.assertEqual(
+                report["errors"],
+                ["non_discriminating_grader_contrast"],
+            )
+            self.assertIn(
+                "requires at least one response-sensitive grader",
+                report["details"][0],
+            )
+
+    def test_malformed_contrast_fails_with_actionable_code(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            skill = _make_schema3_skill(Path(temp))
+            suite_path = skill / "evals" / "evals.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            suite["evals"][0]["counter_reference"] = {"response": 7}
+            _write_json(suite_path, suite)
+            report = audit(skill)
+            self.assertFalse(report["valid"])
+            self.assertEqual(report["errors"], ["invalid_grader_contrast"])
+            self.assertIn("must be a string", report["details"][0])
+
+    def test_schema_three_without_a_discrimination_claim_remains_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            skill = _make_schema3_skill(Path(temp))
+            suite_path = skill / "evals" / "evals.json"
+            provenance_path = skill / "evals" / "provenance.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            suite.pop("grader_discrimination")
+            _write_json(suite_path, suite)
+            provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+            provenance["suite_sha256"] = canonical_sha256(suite)
+            _write_json(provenance_path, provenance)
+            report = audit(skill)
+            self.assertTrue(report["valid"])
+            self.assertEqual(report["grader_discrimination"]["claim"], "none")
+            self.assertEqual(
+                report["grader_discrimination"]["contrast_case_count"],
+                0,
+            )
 
     def test_tampered_provenance_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
@@ -682,7 +775,15 @@ print(json.dumps({
                 },
             )
             self.assertEqual(snapshot["cases"][0]["model_rubric_count"], 0)
-            self.assertFalse(snapshot["cases"][0]["counter_reference_declared"])
+            self.assertEqual(
+                snapshot["cases"][0]["response_sensitive_graders"],
+                [{"name": "Returns done", "type": "response_contains"}],
+            )
+            self.assertTrue(snapshot["cases"][0]["counter_reference_declared"])
+            self.assertEqual(
+                report["grader_discrimination"],
+                {"claim": "case_contrast", "validated": True},
+            )
             policy_notes = [
                 line for line in report["limits"] if "distribution_policy" in line
             ]
@@ -739,23 +840,66 @@ class CounterReferenceTests(unittest.TestCase):
             skill = self._skill_with_counter(root, "this answer is wrong")
             self.assertTrue(self._validate(skill, root / "out"))
 
-    def test_a_counter_reference_that_passes_stops_the_run(self) -> None:
+    def test_a_model_grader_that_accepts_the_counter_stops_the_run(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
-            skill = self._skill_with_counter(root, "done")
-            with self.assertRaisesRegex(ValueError, "counter-reference passed graders"):
+            skill = self._skill_with_counter(root, "this answer is wrong")
+            suite_path = skill / "evals" / "evals.json"
+            provenance_path = skill / "evals" / "provenance.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            suite["evals"][0]["graders"].append(
+                {
+                    "name": "Judge",
+                    "type": "model_rubric",
+                    "rubric": "done",
+                    "criteria": [
+                        {
+                            "requirement": "Returns done",
+                            "prompt_quote": "Return done.",
+                        }
+                    ],
+                }
+            )
+            _write_json(suite_path, suite)
+            provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+            provenance["suite_sha256"] = canonical_sha256(suite)
+            provenance["cases"][0]["case_sha256"] = canonical_sha256(
+                suite["evals"][0]
+            )
+            _write_json(provenance_path, provenance)
+            passing_grade = {"Judge": {"passed": True, "evidence": "fixture"}}
+            with (
+                patch(
+                    "run_skill_eval._model_graders",
+                    return_value=(passing_grade, []),
+                ),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "counter-reference did not fail response-sensitive graders: Judge",
+                ),
+            ):
                 self._validate(skill, root / "out")
 
-    def test_a_suite_without_a_counter_reference_is_unaffected(self) -> None:
+    def test_schema_three_response_graders_require_a_counter_reference(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             skill = _make_schema3_skill(root)
-            self.assertTrue(self._validate(skill, root / "out"))
+            suite_path = skill / "evals" / "evals.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            suite["evals"][0].pop("counter_reference")
+            _write_json(suite_path, suite)
+            with self.assertRaisesRegex(ValueError, "counter_reference is required"):
+                load_suite(skill)
+
+    def test_schema_two_without_a_counter_reference_remains_compatible(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            skill = _make_schema2_skill(root)
             case = load_suite(skill)["evals"][0]
             self.assertIsNone(
                 _grade_counter_reference(
                     case=case,
-                    suite_root=skill / "evals",
+                    suite_root=skill,
                     output_dir=root / "out",
                     harness="pi",
                     executable="unused",
@@ -788,9 +932,19 @@ class CounterReferenceTests(unittest.TestCase):
             provenance["suite_sha256"] = canonical_sha256(suite)
             provenance["cases"][0]["case_sha256"] = canonical_sha256(suite["evals"][0])
             _write_json(provenance_path, provenance)
-            graders.return_value = (
-                {"Judge": {"passed": True, "evidence": "fixture"}},
-                [{"actual_model": "provider/judge-1", "trace_path": "judge.jsonl"}],
+            judge_record = {
+                "actual_model": "provider/judge-1",
+                "trace_path": "judge.jsonl",
+            }
+            graders.side_effect = (
+                (
+                    {"Judge": {"passed": True, "evidence": "fixture"}},
+                    [judge_record],
+                ),
+                (
+                    {"Judge": {"passed": False, "evidence": "fixture"}},
+                    [judge_record],
+                ),
             )
             records = self._validate(skill, root / "out")
             self.assertEqual(
@@ -2881,6 +3035,22 @@ class AggregateTests(unittest.TestCase):
         manifest["reference_validation"] = [reference]
         _write_json(manifest_path, manifest)
 
+    def test_undeclared_grader_discrimination_remains_unproven(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _make_run(root, [(False, True)])
+            report = aggregate(root)
+            self.assertEqual(
+                report["grader_discrimination"],
+                {"claim": "none", "validated": False},
+            )
+            self.assertTrue(
+                any(
+                    "optional counters do not prove every" in limit
+                    for limit in report["limits"]
+                )
+            )
+
     def test_no_judge_calls_have_zero_usage_only_when_zero_are_expected(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
@@ -2992,6 +3162,155 @@ class AggregateTests(unittest.TestCase):
             )
             _write_json(manifest_path, manifest)
             with self.assertRaisesRegex(ValueError, "counter_reference passed"):
+                aggregate(root)
+
+    def test_counter_reference_must_fail_every_response_grader(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _make_run(root, [(False, True)])
+            self._accounting_snapshot(root, graders=0, counter=True)
+            snapshot_path = root / "suite_snapshot.json"
+            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            snapshot["grader_discrimination"] = "case_contrast"
+            snapshot["cases"][0]["response_sensitive_graders"] = [
+                {"name": "Rejects the bad structure", "type": "response_regex"},
+                {
+                    "name": "Judge rejects the bad answer",
+                    "type": "response_contains",
+                },
+            ]
+            _write_json(snapshot_path, snapshot)
+            manifest_path = root / "run_manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["suite_sha256"] = _sha256(snapshot_path)
+            manifest["reference_validation"][0]["grading"] = {
+                "grader": {"kind": "deterministic_mixed", "schema_version": 2},
+                "expectations": [
+                    {
+                        "text": "Rejects the bad structure",
+                        "passed": True,
+                        "evidence": "fixture",
+                        "grader": "response_regex",
+                    },
+                    {
+                        "text": "Judge rejects the bad answer",
+                        "passed": True,
+                        "evidence": "fixture",
+                        "grader": "response_contains",
+                    },
+                ],
+                "summary": {
+                    "passed": 2,
+                    "failed": 0,
+                    "total": 2,
+                    "pass_rate": 1.0,
+                },
+            }
+            manifest["reference_validation"][0]["counter_reference"][
+                "grading"
+            ] = {
+                "grader": {"kind": "deterministic_mixed", "schema_version": 2},
+                "expectations": [
+                    {
+                        "text": "Rejects the bad structure",
+                        "passed": False,
+                        "evidence": "fixture",
+                        "grader": "response_regex",
+                    },
+                    {
+                        "text": "Judge rejects the bad answer",
+                        "passed": True,
+                        "evidence": "fixture",
+                        "grader": "response_contains",
+                    },
+                ],
+                "summary": {
+                    "passed": 1,
+                    "failed": 1,
+                    "total": 2,
+                    "pass_rate": 0.5,
+                },
+            }
+            _write_json(manifest_path, manifest)
+            with self.assertRaisesRegex(
+                ValueError,
+                "counter_reference did not fail response-sensitive graders: "
+                "Judge rejects the bad answer",
+            ):
+                aggregate(root)
+
+    def test_case_contrast_requires_complete_snapshot_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _make_run(root, [(False, True)])
+            self._accounting_snapshot(root, graders=0, counter=True)
+            snapshot_path = root / "suite_snapshot.json"
+            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            snapshot["grader_discrimination"] = "case_contrast"
+            _write_json(snapshot_path, snapshot)
+            manifest_path = root / "run_manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["suite_sha256"] = _sha256(snapshot_path)
+            _write_json(manifest_path, manifest)
+            with self.assertRaisesRegex(
+                ValueError,
+                "response_sensitive_graders must be a list",
+            ):
+                aggregate(root)
+
+    def test_case_contrast_requires_a_counter_for_response_graders(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _make_run(root, [(False, True)])
+            self._accounting_snapshot(root, graders=0, counter=False)
+            snapshot_path = root / "suite_snapshot.json"
+            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            snapshot["grader_discrimination"] = "case_contrast"
+            snapshot["cases"][0]["response_sensitive_graders"] = [
+                {"name": "Completes the task", "type": "response_contains"}
+            ]
+            _write_json(snapshot_path, snapshot)
+            manifest_path = root / "run_manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["suite_sha256"] = _sha256(snapshot_path)
+            _write_json(manifest_path, manifest)
+            with self.assertRaisesRegex(
+                ValueError,
+                "counter_reference_declared must match response-sensitive graders",
+            ):
+                aggregate(root)
+
+    def test_case_contrast_revalidates_each_named_grader(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _make_run(root, [(False, True)])
+            self._accounting_snapshot(root, graders=0, counter=True)
+            snapshot_path = root / "suite_snapshot.json"
+            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            snapshot["grader_discrimination"] = "case_contrast"
+            snapshot["cases"][0]["response_sensitive_graders"] = [
+                {"name": "Completes the task", "type": "response_contains"}
+            ]
+            _write_json(snapshot_path, snapshot)
+            manifest_path = root / "run_manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["suite_sha256"] = _sha256(snapshot_path)
+            _write_json(manifest_path, manifest)
+            report = aggregate(root)
+            self.assertEqual(
+                report["grader_discrimination"],
+                {"claim": "case_contrast", "validated": True},
+            )
+
+            manifest["reference_validation"][0]["counter_reference"]["grading"][
+                "expectations"
+            ][0]["grader"] = "response_regex"
+            _write_json(manifest_path, manifest)
+            with self.assertRaisesRegex(
+                ValueError,
+                "counter_reference.grading does not retain the declared "
+                "response-sensitive grader outcomes",
+            ):
                 aggregate(root)
 
     def test_partial_accounting_metadata_is_rejected(self) -> None:

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -949,11 +949,35 @@ class TargetAttestationOwnerTests(unittest.TestCase):
                 trace_path=Path("/tmp/trace.jsonl"),
             )
 
+    def test_require_reports_cross_provider_same_leaf_mismatch(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            (
+                "requested target model provider-a/model-1 but attested "
+                "provider-b/model-1"
+            ),
+        ):
+            require_target_runtime_attestation(
+                self._ok_metadata(actual_model="provider-b/model-1"),
+                harness="codex",
+                requested_model="provider-a/model-1",
+                condition="without_skill",
+                activation_mode="forced",
+                skill_name="fixture-skill",
+                trace_path=Path("/tmp/trace.jsonl"),
+            )
+
 
 class RuntimeTests(unittest.TestCase):
-    def test_model_identity_rejects_suffix_collisions(self) -> None:
+    def test_model_identity_requires_the_full_provider_and_model(self) -> None:
         self.assertTrue(
+            model_matches(" Provider/GPT-5.6-Terra ", "provider/gpt-5.6-terra")
+        )
+        self.assertFalse(
             model_matches("provider/gpt-5.6-terra", "gpt-5.6-terra")
+        )
+        self.assertFalse(
+            model_matches("provider-a/model-1", "provider-b/model-1")
         )
         self.assertFalse(
             model_matches("provider/model-1", "provider/model-1-preview")
@@ -1330,6 +1354,31 @@ class RuntimeTests(unittest.TestCase):
                 requested_model="gpt-5.6-terra",
                 codex_home=codex_home,
             )
+            self.assertEqual(metadata["actual_model"], "")
+            self.assertFalse(metadata["model_attested"])
+            self.assertTrue(metadata["model_attestation_conflict"])
+
+    def test_same_leaf_models_from_different_providers_conflict(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            trace = Path(temp) / "trace.jsonl"
+            trace.write_text(
+                "\n".join(
+                    json.dumps(
+                        {
+                            "type": "system",
+                            "subtype": "init",
+                            "model": model,
+                        }
+                    )
+                    for model in (
+                        "provider-a/model-1",
+                        "provider-b/model-1",
+                    )
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            metadata = trace_metadata(trace, "")
             self.assertEqual(metadata["actual_model"], "")
             self.assertFalse(metadata["model_attested"])
             self.assertTrue(metadata["model_attestation_conflict"])

--- a/skills/triangulate-me/SKILL.md
+++ b/skills/triangulate-me/SKILL.md
@@ -18,6 +18,8 @@ a proposal for the user to accept, reject, or revise.
 - Split genuinely independent claims and handle them separately.
 - Ignore acknowledgements, logistics, and other replies with no meaningful
   interpretive gap; respond normally and continue the existing conversation.
+  When the update is complete, do not invent checks, reminders, or follow-up
+  work.
 - Find available facts yourself. Ask the user only for judgments, preferences,
   private context, or evidence you cannot inspect.
 
@@ -36,9 +38,10 @@ Apply this sequence:
 3. **Stress read** — Form the weakest interpretation that a reasonable reader
    could still derive from the answer. Complete when it names a specific,
    supported vulnerability—or states that none exists.
-4. **Crux** — Name the exact premise, definition, value, or missing fact that
-   explains the distance between the readings. Complete when resolving it would
-   materially collapse that distance.
+4. **Crux** — State declaratively the exact premise, definition, value, or
+   missing fact that explains the distance between the readings; do not phrase
+   it as a question. Complete when resolving it would materially collapse that
+   distance.
 5. **First-principles check, when triggered** — If the crux contains a
    supposedly fixed constraint (such as "must use X," "too expensive," "can't
    scale," or "that's how it is done"), or a solution justified mainly by
@@ -46,15 +49,22 @@ Apply this sequence:
 6. **Convergence** — Recommend the most robust next formulation. Preserve the
    steel read's value while repairing the stress read's supported vulnerability.
    Complete when it states what was preserved, repaired, or left unresolved;
-   derive it from grounded primitives when the check ran.
-7. **Next question** — Ask one question whose answer resolves the crux. Do not
-   ask a downstream question while its prerequisite remains unsettled. Complete
-   when answering it would settle the current crux.
+   derive it from grounded primitives when the check ran. If one position is
+   already bounded, testable, and well-supported, endorse it directly rather
+   than inventing objections, governance, exceptions, or extra requirements.
+7. **Next question** — Ask zero or one question. Ask only when a material crux
+   remains, and do not repeat the crux in question form. Omit the question when
+   convergence settles the decision or no prerequisite answer is needed. Do not
+   ask a downstream question while its prerequisite remains unsettled.
    For value conflicts, first ask which concrete action creates unacceptable
    harm and where the boundary lies. Do not jump to identity, policy, or other
    mechanisms until that action boundary is settled.
 
-Use this compact form unless the subject needs more explanation:
+Use the sequence as a reasoning discipline, not a mandatory output template.
+Lead with the decision or direct answer. Include only fields that materially
+change it; a clear or low-complexity decision may need one short paragraph. When
+the full frame helps the user inspect a real interpretive gap, use this compact
+form:
 
 ```markdown
 **Faithful read:** ...
@@ -73,8 +83,8 @@ Use this as one bounded pass, separate from the six interpretation fields. Read
 check is triggered. It defines the constraint classes, primitive reduction,
 rebuild, residuals, and kill test. Keep the main response's `Grounding` line
 compact and concrete. Reserve the pass for a false-constraint or borrowed-
-solution signal; keep time-critical incidents and ordinary polish on their
-direct path.
+solution signal; a proposed solution or missing evidence alone is not enough.
+Keep time-critical incidents and ordinary polish on their direct path.
 
 ## Protect the inquiry
 
@@ -85,10 +95,12 @@ direct path.
   disagreement, or abstain pending evidence or a prototype.
 - Route a factual dispute to the named check that could resolve it.
 - When no plausible stress read exists, say so and move to the next unresolved
-  decision.
+  decision without manufacturing a crux or follow-up question.
 - Distinguish an ungrillable question from an unresolved one. Recommend a
   concrete experiment when reaction to evidence, behavior, or a prototype is
-  required.
+  required. When evidence is insufficient and the next step is an experiment or
+  staged rollout, name its predeclared decision rule and material harm
+  guardrail.
 - Keep the user's original language where possible. Mark agent-added language
   and assumptions plainly.
 

--- a/skills/triangulate-me/evals/evals.json
+++ b/skills/triangulate-me/evals/evals.json
@@ -5,10 +5,11 @@
   "dataset_origin": "author_derived",
   "tool_profile": "no_tools",
   "activation_mode": "forced",
+  "grader_discrimination": "case_contrast",
   "provenance_manifest": "provenance.json",
   "distribution_policy": {
     "minimum_pairs": 3,
-    "minimum_effect_size": 0.1,
+    "minimum_effect_size": 0.2,
     "confidence_level": 0.95
   },
   "evals": [
@@ -16,153 +17,197 @@
       "id": "separates-need-from-proposed-feature",
       "behavior_class": "positive",
       "routing_class": "should_trigger",
-      "prompt": "Help me sharpen this product decision through dialogue: We should add team chat because customers keep asking for collaboration. I want the strongest interpretation, the most vulnerable reasonable interpretation, and a better formulation before deciding.",
       "expected_skill_loading": "required",
-      "graders": [
-        {
-          "name": "Uses the complete triangulation frame",
-          "type": "response_regex",
-          "pattern": "(?is)Faithful read.*Steel read.*Stress read.*Crux.*Convergence.*Next question"
-        },
-        {
-          "name": "Separates the customer need from the chat solution",
-          "type": "model_rubric",
-          "criteria": [
-            {
-              "requirement": "Distinguish the observed request for collaboration from the unverified proposed solution of team chat.",
-              "prompt_quote": "team chat because customers keep asking for collaboration"
-            },
-            {
-              "requirement": "Give a charitable interpretation and a plausible vulnerability without caricaturing the user's view.",
-              "prompt_quote": "strongest interpretation, the most vulnerable reasonable interpretation"
-            },
-            {
-              "requirement": "Recommend a formulation that keeps chat as a candidate while making the collaboration job the unresolved crux, then ask one question that resolves that crux.",
-              "prompt_quote": "a better formulation before deciding"
-            }
-          ]
-        }
-      ],
-      "reference": {
-        "response": "**Faithful read:** Customers are asking for collaboration, and team chat is the proposed response.\n\n**Steel read:** Repeated requests may indicate that customers need an in-product communication surface that keeps work and discussion together.\n\n**Stress read:** Collaboration may mean comments, approvals, presence, or sharing rather than chat, so the proposal may be substituting a familiar feature for an unverified job.\n\n**Crux:** Whether customers need synchronous conversation or another coordination mechanism.\n\n**Convergence:** Validate the collaboration job before committing to chat; retain chat as one candidate rather than defining it as the requirement. This changes the decision from which chat to build to which collaboration job is unmet.\n\n**Next question:** What are customers trying to accomplish when they ask for collaboration?"
-      },
-      "counter_reference": {
-        "response": "Team chat is clearly a good idea because collaboration products are popular. You should build Slack-style channels and ship quickly."
-      }
+      "prompt": "We keep hearing, 'we need collaboration.' The team proposes adding team chat. What should our product decision be?",
+      "graders": [{"name": "Separates the collaboration job from chat", "type": "model_rubric", "criteria": [
+        {"requirement": "Separate the reported collaboration need from team chat as a proposed solution.", "prompt_quote": "proposes adding team chat"},
+        {"requirement": "Give a charitable supported benefit and a specific supported alternative interpretation without attributing motives.", "prompt_quote": "we need collaboration"},
+        {"requirement": "Stay proportionate: no unnecessary expansion, and ask at most one decision-resolving question if a material crux remains.", "prompt_quote": "What should our product decision be?"}
+      ]}],
+      "reference": {"response": "The request establishes a collaboration problem, not that chat is the right feature. Chat could keep discussion with work, but collaboration might instead mean comments, approvals, sharing, or presence. The decision is to identify the unmet coordination job before selecting chat. What are users trying to accomplish when they ask for collaboration?"},
+      "counter_reference": {"response": "Team chat is a sensible response to collaboration requests, so define the channel model and add it to the next release."}
     },
     {
       "id": "abstains-pending-database-evidence",
       "behavior_class": "edge",
       "routing_class": "should_trigger",
-      "prompt": "Help me pressure-test this answer: We should replace Postgres with MongoDB because writes are slow, but we have not measured where the latency comes from. Recommend where the two interpretations should converge.",
       "expected_skill_loading": "required",
-      "graders": [
-        {
-          "name": "Uses the complete triangulation frame for an evidence gap",
-          "type": "response_regex",
-          "pattern": "(?is)Faithful read.*Steel read.*Stress read.*Crux.*Convergence.*Next question"
-        },
-        {
-          "name": "Refuses a rhetorical database compromise",
-          "type": "model_rubric",
-          "criteria": [
-            {
-              "requirement": "Treat the database replacement as a hypothesis rather than a settled diagnosis because the source of write latency is unmeasured.",
-              "prompt_quote": "we have not measured where the latency comes from"
-            },
-            {
-              "requirement": "Do not recommend MongoDB, Postgres, or a compromise architecture as the convergence without evidence about the bottleneck.",
-              "prompt_quote": "replace Postgres with MongoDB because writes are slow"
-            },
-            {
-              "requirement": "Converge on a concrete evidence gate and ask one diagnostic question or name one measurement that could resolve the crux.",
-              "prompt_quote": "Recommend where the two interpretations should converge"
-            }
-          ]
-        }
-      ],
-      "reference": {
-        "response": "**Faithful read:** Writes are slow, and replacing Postgres with MongoDB is the proposed remedy; the bottleneck has not been localized.\n\n**Steel read:** If the workload fundamentally conflicts with the current relational write path, a different datastore could remove a structural constraint.\n\n**Stress read:** The proposal attributes latency to the database product without evidence; the cause could be queries, indexes, locks, network, application behavior, or storage.\n\n**Crux:** Whether Postgres itself is the measured bottleneck.\n\n**Convergence:** Treat replacement as an unproven hypothesis and preserve Postgres until profiling identifies the limiting layer. No database choice is justified yet.\n\n**Next question:** Which measurement currently shows where write latency is spent?"
-      },
-      "counter_reference": {
-        "response": "The steelman favors MongoDB and the strawman favors Postgres, so use both databases to meet in the middle."
-      }
+      "prompt": "Writes are slow, and someone proposes replacing Postgres with MongoDB. We have not yet measured where the latency occurs. What is the responsible next decision?",
+      "graders": [{"name": "Defers datastore selection pending latency evidence", "type": "model_rubric", "criteria": [
+        {"requirement": "Treat the database change as a hypothesis because the latency source is unmeasured.", "prompt_quote": "not yet measured where the latency occurs"},
+        {"requirement": "Do not select MongoDB, retain Postgres by default as a conclusion, or prescribe a dual-database compromise before localizing the bottleneck.", "prompt_quote": "replacing Postgres with MongoDB"},
+        {"requirement": "Stay proportionate: name a concrete diagnostic and ask at most one prerequisite question rather than expanding the analysis.", "prompt_quote": "responsible next decision"}
+      ]}],
+      "reference": {"response": "MongoDB may help only if the current datastore is the measured limiting layer; the slow writes could also be queries, locks, indexes, network, or storage. Defer a datastore decision until a trace or profile localizes latency. Which measurement shows where write time is spent?"},
+      "counter_reference": {"response": "Keep Postgres for reads but dual-write new traffic to MongoDB, then compare performance before making a full migration."}
     },
     {
       "id": "preserves-privacy-abuse-value-crux",
       "behavior_class": "edge",
       "routing_class": "should_trigger",
-      "prompt": "Interrogate this position without forcing a centrist answer: Anonymous use protects privacy, but removing anonymity would reduce abuse. Give both plausible readings, preserve any real value conflict, and recommend the next convergence question.",
       "expected_skill_loading": "required",
-      "graders": [
-        {
-          "name": "Uses the complete triangulation frame for a value conflict",
-          "type": "response_regex",
-          "pattern": "(?is)Faithful read.*Steel read.*Stress read.*Crux.*Convergence.*Next question"
-        },
-        {
-          "name": "Preserves the value conflict without false compromise",
-          "type": "model_rubric",
-          "criteria": [
-            {
-              "requirement": "Represent both privacy and abuse prevention as legitimate concerns without inventing motives or treating either as automatically decisive.",
-              "prompt_quote": "Anonymous use protects privacy, but removing anonymity would reduce abuse"
-            },
-            {
-              "requirement": "Identify the product action or harm boundary as the crux instead of assuming the truth lies midway between anonymity and identity.",
-              "prompt_quote": "without forcing a centrist answer"
-            },
-            {
-              "requirement": "Either preserve the value disagreement or propose a conditional boundary clearly marked as a hypothesis, then ask one question that could settle the next decision.",
-              "prompt_quote": "preserve any real value conflict"
-            }
-          ]
-        }
-      ],
-      "reference": {
-        "response": "**Faithful read:** Anonymity supports privacy, while identity may deter or constrain abuse. The answer does not yet rank those values or define which actions are risky.\n\n**Steel read:** Anonymous participation may protect vulnerable users and lower the cost of access; accountability controls may also be necessary where actions can harm others.\n\n**Stress read:** Treating anonymity as globally good or bad hides important differences between reading, speaking, transacting, and administering.\n\n**Crux:** Which anonymous actions create unacceptable harm, and which identity requirements create unacceptable privacy loss.\n\n**Convergence:** Preserve the value conflict and decide at the action boundary rather than forcing one identity rule across the product. A tiered boundary is only a hypothesis until the harmful actions are known.\n\n**Next question:** Which anonymous user action currently creates the most serious abuse?"
-      },
-      "counter_reference": {
-        "response": "Both sides are valid, so require users to reveal half of their identity as a fair compromise."
-      }
+      "prompt": "Anonymous use protects privacy, while removing anonymity may reduce abuse. The product team needs a policy direction.",
+      "graders": [{"name": "Preserves the privacy and abuse value conflict", "type": "model_rubric", "criteria": [
+        {"requirement": "Represent privacy and abuse prevention as legitimate values without inventing motives or automatically ranking either one.", "prompt_quote": "protects privacy"},
+        {"requirement": "Locate the decision in concrete actions and harms rather than choosing an arbitrary midpoint identity rule.", "prompt_quote": "reduce abuse"},
+        {"requirement": "Stay proportionate: preserve the unresolved value choice or state a clearly conditional boundary, with at most one decision-resolving question.", "prompt_quote": "policy direction"}
+      ]}],
+      "reference": {"response": "Anonymity can protect vulnerable people, while accountability may matter for actions that harm others. The missing boundary is which anonymous actions create unacceptable harm and which identity demands create unacceptable privacy loss. Keep that value choice explicit until it is known. Which anonymous action currently causes the most serious abuse?"},
+      "counter_reference": {"response": "Use verified identities for posting but allow anonymous reading; that gives privacy and safety equal weight without delaying the policy."}
     },
     {
       "id": "grounds-false-scale-constraint",
       "behavior_class": "positive",
       "routing_class": "should_trigger",
-      "prompt": "Help me pressure-test this architecture: We have to use a queue because real-time updates cannot scale. Give the strongest plausible reading, the weakest reasonable reading, and a better convergence before we commit.",
       "expected_skill_loading": "required",
-      "graders": [
-        {
-          "name": "Uses the grounding frame when a fixed constraint drives the choice",
-          "type": "response_regex",
-          "pattern": "(?is)Faithful read.*Steel read.*Stress read.*Crux.*Grounding.*Convergence.*Next question"
-        },
-        {
-          "name": "Separates measured capacity from queue convention",
-          "type": "model_rubric",
-          "criteria": [
-            {
-              "requirement": "Treat the claim that real-time updates cannot scale as unproven unless a measurement identifies the binding capacity limit.",
-              "prompt_quote": "real-time updates cannot scale"
-            },
-            {
-              "requirement": "Name supported primitives such as update rate, latency budget, fan-out, or another directly relevant requirement rather than relying on precedent or authority.",
-              "prompt_quote": "We have to use a queue"
-            },
-            {
-              "requirement": "Keep the queue as a candidate architecture, state the residual constraint, and propose a cheap representative load test or other kill test.",
-              "prompt_quote": "before we commit"
-            }
-          ]
-        }
-      ],
-      "reference": {
-        "response": "**Faithful read:** Real-time updates are considered incompatible with the required scale, so a queue is proposed as the remedy.\n\n**Steel read:** A queue may absorb bursts and decouple producers from slower consumers, which could protect a real capacity limit.\n\n**Stress read:** \"Cannot scale\" may be an analogy or unmeasured assumption; the actual limit could be fan-out, connection count, payload size, or an implementation detail, and a queue may add latency without solving it.\n\n**Crux:** Which measured capacity bound makes direct updates fail, and whether the queue addresses that bound.\n\n**Grounding:** Classify the scale claim as a measured fact only if supported by load data; retain the required update rate and latency budget as primitives; reopen the queue-as-requirement assumption; rebuild the smallest transport that meets those bounds; binding residuals are the measured capacity and latency limits; kill-test with representative load.\n\n**Convergence:** Treat the queue as one candidate architecture, not a binding requirement, until the failing capacity and the queue’s effect on it are measured.\n\n**Next question:** What load test or production measurement shows the first capacity bound being exceeded?"
-      },
-      "counter_reference": {
-        "response": "Real-time updates cannot scale, so the queue is clearly required. Adopt a standard queue architecture and optimize it later."
-      }
+      "prompt": "A staging test reached 800 simultaneous connections with p95 update latency of 240 ms. The target traffic, fan-out, and failing component are unknown. The architecture proposal says we must add a queue because real-time updates cannot scale. How should we proceed?",
+      "graders": [{"name": "Distinguishes observed load data from the unproven queue conclusion", "type": "model_rubric", "criteria": [
+        {"requirement": "Distinguish the observed staging measurement from the unknown target, fan-out, and unlocalized bottleneck.", "prompt_quote": "target traffic, fan-out, and failing component are unknown"},
+        {"requirement": "Keep a queue as a candidate rather than treating the observed p95 alone as proof that direct updates cannot scale.", "prompt_quote": "must add a queue"},
+        {"requirement": "Stay proportionate: name a representative load or bottleneck test and ask at most one decision-resolving question.", "prompt_quote": "How should we proceed?"}
+      ]}],
+      "reference": {"response": "The 800-connection p95 is evidence about one staging condition, not the production target or the component causing latency. A queue could help with a measured burst or consumer limit, but it is not established yet. Define the required rate, latency, and fan-out, then run representative tracing and load. What target load and latency budget must the system meet?"},
+      "counter_reference": {"response": "The 240 ms result confirms direct updates cannot scale, so add a queue now and use the next load test only to size it."}
+    },
+    {
+      "id": "weighs-asymmetric-rollout-evidence",
+      "behavior_class": "positive",
+      "routing_class": "should_trigger",
+      "expected_skill_loading": "required",
+      "prompt": "Dana believes yesterday's release caused checkout failures. The recorded deploy was at 09:00, while the error spike began at 06:20; no other causal evidence is available. What should the incident team conclude now?",
+      "graders": [{"name": "Weights timestamp evidence over unsupported attribution", "type": "model_rubric", "criteria": [
+        {"requirement": "Explain that the stated timing weakens the release-caused-failures claim while allowing that the release record could be incomplete.", "prompt_quote": "deploy was at 09:00"},
+        {"requirement": "Do not present Dana's assertion and the known timestamp as equally supported causes.", "prompt_quote": "Dana believes"},
+        {"requirement": "Stay proportionate: defer attribution pending the next causal trace and ask at most one decision-resolving question.", "prompt_quote": "conclude now"}
+      ]}],
+      "reference": {"response": "The known timing does not support blaming the 09:00 release for a 06:20 spike, although an incomplete deployment record remains possible. Do not assign cause yet; inspect changes, configuration, and traffic immediately before the spike. What trace or change appears just before 06:20?"},
+      "counter_reference": {"response": "Record the release as the leading cause but keep an investigation open in case an earlier configuration change also contributed."}
+    },
+    {
+      "id": "rejects-anecdote-against-measured-accessibility",
+      "behavior_class": "positive",
+      "routing_class": "should_trigger",
+      "expected_skill_loading": "required",
+      "prompt": "One executive says the low-contrast palette feels premium. Moderated testing found six of eight low-vision participants could not complete payment. Which redesign direction should the team take?",
+      "graders": [{"name": "Lets observed payment exclusion outweigh a taste preference", "type": "model_rubric", "criteria": [
+        {"requirement": "Treat the observed payment-completion barrier as stronger decision evidence than one aesthetic preference.", "prompt_quote": "six of eight low-vision participants could not complete payment"},
+        {"requirement": "Recommend an accessible redesign rather than an unvalidated middle contrast that may keep users from paying.", "prompt_quote": "low-contrast palette feels premium"},
+        {"requirement": "Stay proportionate: preserve the premium goal as a secondary design constraint and ask at most one validation question.", "prompt_quote": "Which redesign direction"}
+      ]}],
+      "reference": {"response": "Use a contrast treatment that lets low-vision users complete payment. The premium goal still matters, but it must be satisfied within an accessible design rather than against observed exclusion. Does the revised palette pass the same payment test?"},
+      "counter_reference": {"response": "Raise contrast slightly but keep the current palette family, then revisit it only if sales decline after launch."}
+    },
+    {
+      "id": "clarifies-ambiguous-deadline-requirement",
+      "behavior_class": "edge",
+      "routing_class": "should_trigger",
+      "expected_skill_loading": "required",
+      "prompt": "The requirement says, 'make onboarding fast by Friday.' Product wants new users to reach a first useful result sooner; engineering has proposed reducing page-load time. What should be agreed before work begins?",
+      "graders": [{"name": "Defines the onboarding outcome before choosing a proxy", "type": "model_rubric", "criteria": [
+        {"requirement": "Identify that faster first useful result and faster page loading are different possible meanings of fast.", "prompt_quote": "first useful result sooner"},
+        {"requirement": "Keep the Friday deadline distinct from the unresolved success definition rather than selecting page-load work by default.", "prompt_quote": "by Friday"},
+        {"requirement": "Stay proportionate: ask at most one question that defines the outcome or metric before implementation selection.", "prompt_quote": "before work begins"}
+      ]}],
+      "reference": {"response": "Agree on the onboarding outcome and its metric first: a quick load can help, but it does not prove users reach value sooner. The Friday date sets urgency, not the success definition. What event and time threshold mark a new user's first useful result?"},
+      "counter_reference": {"response": "Set a two-second page-load target and remove one onboarding screen; those two changes cover both interpretations."}
+    },
+    {
+      "id": "clarifies-ambiguous-security-scope",
+      "behavior_class": "edge",
+      "routing_class": "should_trigger",
+      "expected_skill_loading": "required",
+      "prompt": "The request is to encrypt customer data at rest. This service stores names, session tokens, backups, application logs, and support exports. What needs clarification before implementation?",
+      "graders": [{"name": "Scopes encryption coverage before prescribing a control", "type": "model_rubric", "criteria": [
+        {"requirement": "Identify ambiguity in the relevant data classes, storage locations, and threat boundary.", "prompt_quote": "names, session tokens, backups, application logs, and support exports"},
+        {"requirement": "Avoid claiming one generic encryption setting protects every listed surface or threat.", "prompt_quote": "encrypt customer data at rest"},
+        {"requirement": "Stay proportionate: ask at most one scoping question that can establish required coverage before implementation.", "prompt_quote": "before implementation"}
+      ]}],
+      "reference": {"response": "Clarify which stores and data types are covered and which at-rest threat the requirement addresses. A database setting may not cover logs, exports, backups, token handling, or key access. Which data locations and threat scenarios must this requirement protect?"},
+      "counter_reference": {"response": "Enable managed-database encryption and document that exports and backups inherit the same protection model."}
+    },
+    {
+      "id": "recognizes-strong-operational-claim",
+      "behavior_class": "positive",
+      "routing_class": "should_trigger",
+      "expected_skill_loading": "required",
+      "prompt": "A draft production-migration policy requires a named owner, a tested recovery path appropriate to the migration, and an observable success condition. Should this be the baseline?",
+      "graders": [{"name": "Accepts a bounded recovery-aware operational baseline", "type": "model_rubric", "criteria": [
+        {"requirement": "Recognize the named owner, tested recovery path, and observable success condition as a concrete operational baseline.", "prompt_quote": "tested recovery path appropriate to the migration"},
+        {"requirement": "Allow recovery to be rollback or forward recovery as applicable; do not require rollback for every irreversible migration.", "prompt_quote": "appropriate to the migration"},
+        {"requirement": "Stay proportionate: do not manufacture contrary balance or ask a question unless a genuine material scope gap remains.", "prompt_quote": "Should this be the baseline?"}
+      ]}],
+      "reference": {"response": "Yes. The policy makes ownership, recoverability, and verification explicit. The recovery path can be rollback where reversible or tested forward recovery where it is not. No material counter-position is supplied, so adopt it as the baseline without adding a question."},
+      "counter_reference": {"response": "Make tested rollback mandatory for every migration; forward recovery is too uncertain to count as a real safeguard."}
+    },
+    {
+      "id": "rejects-clearly-unsafe-shortcut",
+      "behavior_class": "positive",
+      "routing_class": "should_trigger",
+      "expected_skill_loading": "required",
+      "prompt": "To ship today, the team suggests disabling server-side authorization on an admin export route and hiding the UI button. The route returns all customer records. What is the release decision?",
+      "graders": [{"name": "Rejects UI concealment as protection for a sensitive endpoint", "type": "model_rubric", "criteria": [
+        {"requirement": "State that hiding a UI control does not protect an endpoint returning all customer records.", "prompt_quote": "hiding the UI button"},
+        {"requirement": "Keep server-side authorization or remove/restrict the route; do not endorse a partial control that exposes records.", "prompt_quote": "disabling server-side authorization"},
+        {"requirement": "Stay proportionate: preserve the deadline only through a safe scope reduction or delay, with at most one decision-resolving question.", "prompt_quote": "To ship today"}
+      ]}],
+      "reference": {"response": "Do not ship the route without server-side authorization. A hidden button does not prevent direct access to an endpoint returning all records. Keep authorization, restrict the export to an authorized minimum, or delay the feature. What smallest authorized export scope can ship today?"},
+      "counter_reference": {"response": "Keep authorization for the UI flow but allow the export endpoint during the launch window because its URL is not advertised."}
+    },
+    {
+      "id": "abstains-on-insufficient-experiment-sample",
+      "behavior_class": "edge",
+      "routing_class": "should_trigger",
+      "expected_skill_loading": "required",
+      "prompt": "Variant B converted 6 of 12 visitors and Variant A converted 4 of 11. There is no segmentation or prior baseline. The team is deciding whether to change the default today. What is warranted?",
+      "graders": [{"name": "Defers a default change while allowing a defined reversible experiment", "type": "model_rubric", "criteria": [
+        {"requirement": "Treat the small observed difference as insufficient to establish that B should become the default.", "prompt_quote": "6 of 12 visitors and Variant A converted 4 of 11"},
+        {"requirement": "Reject an arbitrary split or universal rollout, while allowing a monitored 50/50 experiment only when it has a predeclared decision rule and guardrails.", "prompt_quote": "change the default today"},
+        {"requirement": "Stay proportionate: name the missing evidence or decision rule and ask at most one prerequisite question.", "prompt_quote": "no segmentation or prior baseline"}
+      ]}],
+      "reference": {"response": "The sample is too small and unsegmented to make B the default. Continue a monitored 50/50 only if the team first defines its sample target, success rule, and guardrails; otherwise collect that evidence before changing exposure. What decision rule and harm guardrails will govern the next sample?"},
+      "counter_reference": {"response": "Keep a permanent 50/50 split for now so both variants remain represented while the team watches conversion informally."}
+    },
+    {
+      "id": "preserves-retention-versus-deletion-values",
+      "behavior_class": "edge",
+      "routing_class": "should_trigger",
+      "expected_skill_loading": "required",
+      "prompt": "Support wants to retain chat transcripts indefinitely to resolve disputes. Privacy wants automatic deletion after 30 days to limit exposure. Neither the dispute rate nor the harm is quantified. What policy work comes next?",
+      "graders": [{"name": "Keeps retention and privacy values explicit pending evidence", "type": "model_rubric", "criteria": [
+        {"requirement": "Represent dispute resolution and exposure reduction as distinct legitimate values.", "prompt_quote": "retain chat transcripts indefinitely"},
+        {"requirement": "Do not choose an arbitrary middle retention period without evidence or an explicit value judgment.", "prompt_quote": "automatic deletion after 30 days"},
+        {"requirement": "Stay proportionate: identify the concrete dispute or exposure boundary and ask at most one decision-resolving question.", "prompt_quote": "Neither the dispute rate nor the harm is quantified"}
+      ]}],
+      "reference": {"response": "Long retention may support legitimate dispute resolution, while deletion reduces exposure; the given facts do not rank those values. Determine which disputes need records and how harm changes with retention before choosing a duration. Which dispute types require transcripts, and for how long?"},
+      "counter_reference": {"response": "Retain transcripts for six months, then review exceptions, because that is a practical balance between the two proposals."}
+    },
+    {
+      "id": "does-not-trigger-for-acknowledgement",
+      "behavior_class": "negative",
+      "routing_class": "ambiguous",
+      "expected_skill_loading": "required",
+      "prompt": "Thanks, that makes sense.",
+      "graders": [{"name": "Keeps a forced-skill acknowledgement compact", "type": "model_rubric", "criteria": [
+        {"requirement": "Give a brief ordinary acknowledgement appropriate to the message.", "prompt_quote": "Thanks"},
+        {"requirement": "Do not introduce competing readings, an evidence gate, or an invented unresolved concern.", "prompt_quote": "that makes sense"},
+        {"requirement": "Stay proportionate: do not expand the response or ask a question because no decision crux is present.", "prompt_quote": "Thanks, that makes sense."}
+      ]}],
+      "reference": {"response": "You're welcome."},
+      "counter_reference": {"response": "I hear agreement, but it could also conceal a concern; the next step is to identify what remains unresolved."}
+    },
+    {
+      "id": "does-not-trigger-for-simple-logistics",
+      "behavior_class": "negative",
+      "routing_class": "ambiguous",
+      "expected_skill_loading": "required",
+      "prompt": "The calendar invite for tomorrow at 2 PM has already been sent to the three listed people. Is there anything else I need to do?",
+      "graders": [{"name": "Keeps a forced-skill logistics response direct", "type": "model_rubric", "criteria": [
+        {"requirement": "Treat the message as straightforward logistics rather than a claim needing interpretive analysis.", "prompt_quote": "already been sent"},
+        {"requirement": "Do not invent disagreement, a crux, or competing interpretations from the scheduling details.", "prompt_quote": "three listed people"},
+        {"requirement": "Stay proportionate: give a compact no-action response and ask no question because no material decision crux is supplied.", "prompt_quote": "anything else I need to do"}
+      ]}],
+      "reference": {"response": "No further action is indicated from the information provided."},
+      "counter_reference": {"response": "Before deciding whether anything else is needed, separate the scheduling goal from the invitation mechanism and identify each attendee's underlying preference."}
     }
   ]
 }

--- a/skills/triangulate-me/evals/provenance.json
+++ b/skills/triangulate-me/evals/provenance.json
@@ -1,50 +1,20 @@
 {
   "schema_version": 1,
-  "suite_sha256": "3e315ca2de0daece585ef9fd0b1c8d71f270534b0cb3534a163f4041d05ba381",
+  "suite_sha256": "072040117c0174045911f37110fd827e426bf21f9d8d65ba4999eb483cd80191",
   "cases": [
-    {
-      "case_id": "separates-need-from-proposed-feature",
-      "origin": "author_derived",
-      "source_id": "triangulate-me-author-scenario-separates-need-from-proposed-feature",
-      "source_type": "author_scenario",
-      "observed_at": "2026-08-08",
-      "task_author": "Codex with user authorization",
-      "artifact": "provenance/separates-need-from-proposed-feature.json",
-      "artifact_sha256": "444669221147891a099c501a9929b7a15c5d087cd821fe8c2c574a7ffe00527f",
-      "case_sha256": "073ec383401a37ebb2f9d463716669e94562c3effd8bb27d3f00db1ded46ebaf"
-    },
-    {
-      "case_id": "abstains-pending-database-evidence",
-      "origin": "author_derived",
-      "source_id": "triangulate-me-author-scenario-abstains-pending-database-evidence",
-      "source_type": "author_scenario",
-      "observed_at": "2026-08-08",
-      "task_author": "Codex with user authorization",
-      "artifact": "provenance/abstains-pending-database-evidence.json",
-      "artifact_sha256": "d53ba205f1876388e31088ed12fd8710ce9bedde8b081847989007ea4b1172bb",
-      "case_sha256": "4caa11c16e0f42c7d87e5ccbcbeb52d0451db094dee9d0703844474e303dbba6"
-    },
-    {
-      "case_id": "preserves-privacy-abuse-value-crux",
-      "origin": "author_derived",
-      "source_id": "triangulate-me-author-scenario-preserves-privacy-abuse-value-crux",
-      "source_type": "author_scenario",
-      "observed_at": "2026-08-08",
-      "task_author": "Codex with user authorization",
-      "artifact": "provenance/preserves-privacy-abuse-value-crux.json",
-      "artifact_sha256": "65aa99387d02c29f4f2148a2e0615f743d0224274a644273035610f95cb4bf8d",
-      "case_sha256": "ec920ab3a9c4075654f1a758aea1293660452666f3a755639bca987294918d3d"
-    },
-    {
-      "case_id": "grounds-false-scale-constraint",
-      "origin": "author_derived",
-      "source_id": "triangulate-me-author-scenario-grounds-false-scale-constraint",
-      "source_type": "author_scenario",
-      "observed_at": "2026-08-09",
-      "task_author": "Codex with user authorization",
-      "artifact": "provenance/grounds-false-scale-constraint.json",
-      "artifact_sha256": "08907f7ee2bce8f9b3c95b79641416c971c001ce5067bac7692e29e779584510",
-      "case_sha256": "7533ad967ab907202709884f549abb8ec062084ded9d971142f25c0c7864a04e"
-    }
+    {"case_id": "separates-need-from-proposed-feature", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-separates-need-from-proposed-feature", "source_type": "author_scenario", "observed_at": "2026-08-08", "task_author": "Codex with user authorization", "artifact": "provenance/separates-need-from-proposed-feature.json", "artifact_sha256": "444669221147891a099c501a9929b7a15c5d087cd821fe8c2c574a7ffe00527f", "case_sha256": "afa11b4182b1c37b04df2c37ca3ec20e0393f48e75edf307380a42cd263a4fdc"},
+    {"case_id": "abstains-pending-database-evidence", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-abstains-pending-database-evidence", "source_type": "author_scenario", "observed_at": "2026-08-08", "task_author": "Codex with user authorization", "artifact": "provenance/abstains-pending-database-evidence.json", "artifact_sha256": "d53ba205f1876388e31088ed12fd8710ce9bedde8b081847989007ea4b1172bb", "case_sha256": "664af55428e73233ab9bd7865dbdc04f8ae565abf73cb2fc82d0a9ed1259d573"},
+    {"case_id": "preserves-privacy-abuse-value-crux", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-preserves-privacy-abuse-value-crux", "source_type": "author_scenario", "observed_at": "2026-08-08", "task_author": "Codex with user authorization", "artifact": "provenance/preserves-privacy-abuse-value-crux.json", "artifact_sha256": "65aa99387d02c29f4f2148a2e0615f743d0224274a644273035610f95cb4bf8d", "case_sha256": "483366ff39fdda611b88cd6b4ad0bf7f54e60f531acfdb4eb2579681ca27f126"},
+    {"case_id": "grounds-false-scale-constraint", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-grounds-false-scale-constraint", "source_type": "author_scenario", "observed_at": "2026-08-09", "task_author": "Codex with user authorization", "artifact": "provenance/grounds-false-scale-constraint.json", "artifact_sha256": "bde3488e56f3e58097c85d47c8660de988ebaf68518064c536c1ec3751df3bbf", "case_sha256": "455d8a4a24d81437afb3e70d29eb30b4d7effc96a5ff2f1a6790429a67b03c76"},
+    {"case_id": "weighs-asymmetric-rollout-evidence", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-weighs-asymmetric-rollout-evidence", "source_type": "author_scenario", "observed_at": "2026-08-12", "task_author": "Codex with user authorization", "artifact": "provenance/weighs-asymmetric-rollout-evidence.json", "artifact_sha256": "44758811325f0f4d023bd7a4713ff41aa7d5f0fbe55c1018682b976c7497cb3e", "case_sha256": "fa15ae01d5d4d0dbc9551ac1b0d7a6b8cfbcabf3557b5b0f36c8498753a5a0c1"},
+    {"case_id": "rejects-anecdote-against-measured-accessibility", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-rejects-anecdote-against-measured-accessibility", "source_type": "author_scenario", "observed_at": "2026-08-12", "task_author": "Codex with user authorization", "artifact": "provenance/rejects-anecdote-against-measured-accessibility.json", "artifact_sha256": "433376887659fa8a3124910488142d53aa80d37b20c307b94a8b8c3e322c10a5", "case_sha256": "ffd89f4c55a6497d46f592369b334dc4d300ff1fd0fec6008f038f6629dc3a47"},
+    {"case_id": "clarifies-ambiguous-deadline-requirement", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-clarifies-ambiguous-deadline-requirement", "source_type": "author_scenario", "observed_at": "2026-08-12", "task_author": "Codex with user authorization", "artifact": "provenance/clarifies-ambiguous-deadline-requirement.json", "artifact_sha256": "b0774af605dd2334c823a75e0cf7e8503993c54a3c193f848edfd62aa1f5f069", "case_sha256": "1aa6e418561ed97696cbe59b72a8d83dca62269442add269a68b3f02ab5b77b6"},
+    {"case_id": "clarifies-ambiguous-security-scope", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-clarifies-ambiguous-security-scope", "source_type": "author_scenario", "observed_at": "2026-08-12", "task_author": "Codex with user authorization", "artifact": "provenance/clarifies-ambiguous-security-scope.json", "artifact_sha256": "38b84bfe5ca1c99cbfd7add477e1949b96d94e8c741629ecda377536209d3416", "case_sha256": "1400cddd44fc84be6ef59adb9909b1f32625c8b914015beed77b4b963027ac9a"},
+    {"case_id": "recognizes-strong-operational-claim", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-recognizes-strong-operational-claim", "source_type": "author_scenario", "observed_at": "2026-08-12", "task_author": "Codex with user authorization", "artifact": "provenance/recognizes-strong-operational-claim.json", "artifact_sha256": "2ab8826f1ac660d983f8095072d942725d33b704af1a7c9d912959a1119857ac", "case_sha256": "3c831dbc81b186cccaf2ca8b65e514ffd1ebe4d5a8b42440880446505f543788"},
+    {"case_id": "rejects-clearly-unsafe-shortcut", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-rejects-clearly-unsafe-shortcut", "source_type": "author_scenario", "observed_at": "2026-08-12", "task_author": "Codex with user authorization", "artifact": "provenance/rejects-clearly-unsafe-shortcut.json", "artifact_sha256": "5250823de4456e068ab929b800d3ef3671db942446747b57ea8380c4049479a7", "case_sha256": "dd7044fc153d32974dddbc255dcd20dc44f6683ba8fba10651ae26b709c1f706"},
+    {"case_id": "abstains-on-insufficient-experiment-sample", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-abstains-on-insufficient-experiment-sample", "source_type": "author_scenario", "observed_at": "2026-08-12", "task_author": "Codex with user authorization", "artifact": "provenance/abstains-on-insufficient-experiment-sample.json", "artifact_sha256": "60edfba1d56c4d6fdab95a809d61adedf000748a6a61aa24abeabc3632c929b9", "case_sha256": "47af6a49594527812b10fb0b999ac1e583493bf8ee34771753e439e4285bf0a3"},
+    {"case_id": "preserves-retention-versus-deletion-values", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-preserves-retention-versus-deletion-values", "source_type": "author_scenario", "observed_at": "2026-08-12", "task_author": "Codex with user authorization", "artifact": "provenance/preserves-retention-versus-deletion-values.json", "artifact_sha256": "7aff9b1b016927f7947b9282429a029c769d5c56e7b87ea4d3f94ee3430e1fc5", "case_sha256": "7fb9303cbdff2804976aa540f8663274d350720b6811ac62e764f59d1ba954aa"},
+    {"case_id": "does-not-trigger-for-acknowledgement", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-does-not-trigger-for-acknowledgement", "source_type": "author_scenario", "observed_at": "2026-08-12", "task_author": "Codex with user authorization", "artifact": "provenance/does-not-trigger-for-acknowledgement.json", "artifact_sha256": "9428a6ea9107f571727e9412310301d09a407877e299d7c557dc13903e6dcfed", "case_sha256": "fb5dd9a6406bf4072ace8d4b39dd78988b0b7754942c369a4ade76e31543479a"},
+    {"case_id": "does-not-trigger-for-simple-logistics", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-does-not-trigger-for-simple-logistics", "source_type": "author_scenario", "observed_at": "2026-08-12", "task_author": "Codex with user authorization", "artifact": "provenance/does-not-trigger-for-simple-logistics.json", "artifact_sha256": "b612b70ebb7a683cfcbf63edae148192961a8679ba454fb330ddf84f1e7c9e7a", "case_sha256": "8330dc2708c090e1c45cc630a23ee09b1531b5938aba7c095b10661114135d0a"}
   ]
 }

--- a/skills/triangulate-me/evals/provenance/abstains-on-insufficient-experiment-sample.json
+++ b/skills/triangulate-me/evals/provenance/abstains-on-insufficient-experiment-sample.json
@@ -1,0 +1,7 @@
+{
+  "case_id": "abstains-on-insufficient-experiment-sample",
+  "origin": "author_derived",
+  "purpose": "Test that a tiny unsegmented conversion difference routes to a defined reversible evidence gate rather than a default change or an arbitrary midpoint.",
+  "derived_from": ["Evidence-sensitive convergence requirement", "Author-created experiment scenario"],
+  "expected_failure_without_skill": "Declare the higher small-sample conversion rate a global winner or retain a 50/50 split without a predeclared decision rule and guardrails."
+}

--- a/skills/triangulate-me/evals/provenance/clarifies-ambiguous-deadline-requirement.json
+++ b/skills/triangulate-me/evals/provenance/clarifies-ambiguous-deadline-requirement.json
@@ -1,0 +1,7 @@
+{
+  "case_id": "clarifies-ambiguous-deadline-requirement",
+  "origin": "author_derived",
+  "purpose": "Test that an ambiguous outcome requirement is resolved before its technical proxy is selected.",
+  "derived_from": ["Crux identification requirement in Triangulate Me", "Author-created product requirement scenario"],
+  "expected_failure_without_skill": "Treat page-load optimization as synonymous with time-to-value or use the deadline to avoid defining success."
+}

--- a/skills/triangulate-me/evals/provenance/clarifies-ambiguous-security-scope.json
+++ b/skills/triangulate-me/evals/provenance/clarifies-ambiguous-security-scope.json
@@ -1,0 +1,7 @@
+{
+  "case_id": "clarifies-ambiguous-security-scope",
+  "origin": "author_derived",
+  "purpose": "Test that a broad security phrase is scoped to data locations and threats before an implementation is prescribed.",
+  "derived_from": ["Crux identification requirement in Triangulate Me", "Author-created security scope scenario"],
+  "expected_failure_without_skill": "Claim that one database encryption setting covers logs, exports, tokens, backups, and every threat."
+}

--- a/skills/triangulate-me/evals/provenance/does-not-trigger-for-acknowledgement.json
+++ b/skills/triangulate-me/evals/provenance/does-not-trigger-for-acknowledgement.json
@@ -1,0 +1,7 @@
+{
+  "case_id": "does-not-trigger-for-acknowledgement",
+  "origin": "author_derived",
+  "purpose": "Test that forced capability loading still yields a compact ordinary response to a non-substantive acknowledgement.",
+  "derived_from": ["Non-substantive answer boundary in interaction examples", "Author-created conversational boundary scenario"],
+  "expected_failure_without_skill": "Expand into an interpretive frame or invent an unresolved concern from a simple thanks."
+}

--- a/skills/triangulate-me/evals/provenance/does-not-trigger-for-simple-logistics.json
+++ b/skills/triangulate-me/evals/provenance/does-not-trigger-for-simple-logistics.json
@@ -1,0 +1,7 @@
+{
+  "case_id": "does-not-trigger-for-simple-logistics",
+  "origin": "author_derived",
+  "purpose": "Test that forced capability loading still yields a compact no-action response to a complete logistics status update.",
+  "derived_from": ["Establish-the-decision boundary in Triangulate Me", "Author-created scheduling scenario"],
+  "expected_failure_without_skill": "Invent competing interpretations or a decision process around a complete scheduling status update."
+}

--- a/skills/triangulate-me/evals/provenance/grounds-false-scale-constraint.json
+++ b/skills/triangulate-me/evals/provenance/grounds-false-scale-constraint.json
@@ -1,11 +1,11 @@
 {
   "case_id": "grounds-false-scale-constraint",
   "origin": "author_derived",
-  "purpose": "Test whether the skill grounds an apparently fixed scale constraint in measured capacity and primitives before accepting a queue as required.",
+  "purpose": "Test that the skill distinguishes one incomplete staging observation from unknown production targets and an unlocalized bottleneck before accepting a queue as required.",
   "derived_from": [
     "The first-principles constraint classification and rebuild protocol",
     "The existing triangulation faithful/steel/stress/crux/convergence loop",
     "The requirement to preserve evidence gates and avoid false compromise"
   ],
-  "expected_failure_without_skill": "Accept the queue as mandatory because real-time updates supposedly cannot scale, without identifying the capacity bound, supported primitives, or a falsifying load test."
+  "expected_failure_without_skill": "Treat the observed staging p95 as proof that direct updates cannot scale and adopt a queue without target bounds or bottleneck evidence."
 }

--- a/skills/triangulate-me/evals/provenance/preserves-retention-versus-deletion-values.json
+++ b/skills/triangulate-me/evals/provenance/preserves-retention-versus-deletion-values.json
@@ -1,0 +1,7 @@
+{
+  "case_id": "preserves-retention-versus-deletion-values",
+  "origin": "author_derived",
+  "purpose": "Test that a retention-versus-privacy conflict remains explicit until concrete harms and use cases are known.",
+  "derived_from": ["Value-conflict boundary in Triangulate Me", "Author-created policy scenario"],
+  "expected_failure_without_skill": "Choose a random duration as if arithmetic distance between two values resolved the policy conflict."
+}

--- a/skills/triangulate-me/evals/provenance/recognizes-strong-operational-claim.json
+++ b/skills/triangulate-me/evals/provenance/recognizes-strong-operational-claim.json
@@ -1,0 +1,7 @@
+{
+  "case_id": "recognizes-strong-operational-claim",
+  "origin": "author_derived",
+  "purpose": "Test that the skill accepts a concrete operational baseline while allowing rollback or forward recovery according to migration reversibility.",
+  "derived_from": ["No-plausible-stress-read boundary in interaction examples", "Author-created release policy scenario"],
+  "expected_failure_without_skill": "Manufacture false balance, weaken the baseline, or falsely require rollback for irreversible migrations that need tested forward recovery."
+}

--- a/skills/triangulate-me/evals/provenance/rejects-anecdote-against-measured-accessibility.json
+++ b/skills/triangulate-me/evals/provenance/rejects-anecdote-against-measured-accessibility.json
@@ -1,0 +1,7 @@
+{
+  "case_id": "rejects-anecdote-against-measured-accessibility",
+  "origin": "author_derived",
+  "purpose": "Test that measured inability to complete a core flow defeats a single aesthetic preference without discarding the brand goal.",
+  "derived_from": ["Evidence-weighting requirement in Triangulate Me", "Author-created accessibility decision scenario"],
+  "expected_failure_without_skill": "Choose arbitrary medium contrast or treat one executive preference as equivalent to observed checkout exclusion."
+}

--- a/skills/triangulate-me/evals/provenance/rejects-clearly-unsafe-shortcut.json
+++ b/skills/triangulate-me/evals/provenance/rejects-clearly-unsafe-shortcut.json
@@ -1,0 +1,7 @@
+{
+  "case_id": "rejects-clearly-unsafe-shortcut",
+  "origin": "author_derived",
+  "purpose": "Test that a real deadline cannot justify replacing server-side authorization with UI concealment for a sensitive route.",
+  "derived_from": ["False-compromise constraints", "Author-created authorization scenario"],
+  "expected_failure_without_skill": "Offer a release-speed/security midpoint that leaves a public customer-record endpoint unprotected."
+}

--- a/skills/triangulate-me/evals/provenance/weighs-asymmetric-rollout-evidence.json
+++ b/skills/triangulate-me/evals/provenance/weighs-asymmetric-rollout-evidence.json
@@ -1,0 +1,7 @@
+{
+  "case_id": "weighs-asymmetric-rollout-evidence",
+  "origin": "author_derived",
+  "purpose": "Test that explicit timestamps outweigh unsupported causal attribution while leaving incomplete operational records open.",
+  "derived_from": ["Evidence-weighting requirement in Triangulate Me", "Author-created incident timeline"],
+  "expected_failure_without_skill": "Treat a person's causal claim and contradictory timestamp as equally supported, or blame the later deployment without evidence."
+}


### PR DESCRIPTION
## What changed

- expands triangulate-me to a 14-case, schema-v3 behavioral corpus covering factual disagreement, value conflict, ambiguous requirements, asymmetric evidence, argument strength, justified abstention, clear winners, and non-trigger boundaries
- uses semantic response-sensitive graders with explicit references, counter-references, and per-case provenance
- makes minimal interaction changes so the skill can endorse a clear winner, abstain when evidence is weak, avoid invented disagreement, ask at most one non-duplicate question, and stay concise for straightforward requests
- hardens the evaluation harness around full provider/model attestation and grader-contrast validation

## Why

The released one-trial 14-case pilot exposed a regression: treatment scored 7/14 versus control at 10/14 and used roughly three times as many target tokens. Manual review traced this primarily to mandatory framing, duplicated questions, and manufactured objections or follow-ups.

## Evidence

- valid capped repeated run on five high-risk cases: treatment 5/5, control 1/5, +0.80 absolute effect; four improvements, zero regressions, one tied pass
- no critical false-consensus, duplicated-question, or invented-logistics failure in that run
- full 14-case suite audit passes with 14 response-sensitive semantic graders and 14 provenance records
- 18 repository tests pass
- 120 skill-eval-loop tests pass
- Ruff, whitespace, skill validation, evaluator healthcheck, package discovery, and tink skill check pass

## Scope and limitations

The live repeated run was intentionally capped at 30 harness invocations after the broader matrix was judged excessive. This supports a focused release review, not a universal reliability claim. The target and judge used the same model family, which remains a limitation. Local ignored run artifacts were inspected manually and are not committed.

Post-merge, triangulate-me still needs a Tink-managed refresh and byte-for-byte installed-copy verification; the current installed copy correctly remains the prior released version.
