### PR TITLE
Distinguish harness implementation from release proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ expansion. Cross-project catalog history is optional. Detail:
 
 ## skill-eval-loop
 
-Paired diagnostic under Hermes, Claude Code, Codex, or Pi: same task, skill on
-vs off. One question at a time; dry-run free; live runs wait for your invocation
-budget. Missing suites can be authored in a fresh subagent so cases stay sealed.
-Claim boundaries:
+Implemented paired-diagnostic adapters for Hermes, Claude Code, Codex, and Pi:
+same task, skill on vs off. One question at a time; dry-run free; live runs wait
+for your invocation budget. Implementation is not a claim that every real CLI
+has passed on the current release candidate; see the dated
+[harness evidence matrix](skills/skill-eval-loop/references/harness-support.md).
+Missing suites can be authored in a fresh subagent so cases stay sealed. Claim boundaries:
 [skills/skill-eval-loop/references/interpret-benchmark.md](skills/skill-eval-loop/references/interpret-benchmark.md).
 Full contract: [skills/skill-eval-loop/SKILL.md](skills/skill-eval-loop/SKILL.md).
 

--- a/skills/skill-eval-loop/SKILL.md
+++ b/skills/skill-eval-loop/SKILL.md
@@ -74,7 +74,9 @@ Order:
 
 ### 1. Choose the execution harness
 
-Name every supported harness before the first evaluation command:
+Name every implemented harness before the first evaluation command, and link
+the current [harness evidence matrix](references/harness-support.md). An
+implemented adapter is not necessarily release-verified against its real CLI.
 
 - `hermes` — Hermes Agent
 - `claude-code` — Claude Code

--- a/skills/skill-eval-loop/references/harness-support.md
+++ b/skills/skill-eval-loop/references/harness-support.md
@@ -1,0 +1,35 @@
+# Harness evidence matrix
+
+Last reviewed: 2026-08-12 (America/Chicago).
+
+The evaluator implements adapters for four harnesses. “Implemented” means the
+repository constructs isolated invocations, parses traces, and exercises a
+complete fake run in the deterministic test suite. It does not mean a real
+installed CLI has passed on the immutable release candidate.
+
+| Harness | Deterministic repository evidence | Latest real-CLI evidence | Release status |
+| --- | --- | --- | --- |
+| Pi | `RuntimeTests`, `EndToEndTests.test_fake_runs_complete_for_every_selected_harness` | 2026-08-13 UTC: valid five-case bounded diagnostic against the current `triangulate-me` payload; local ignored `.eval-runs/triangulate-me/run-20260813T-candidate-v1-five-risk-cases/` only | Implemented; release verification pending |
+| Codex | `RuntimeTests` cover isolated home, persisted rollout, model identity, and forced-skill access; fake end-to-end run | Not established for the current candidate | Implemented; release verification pending |
+| Claude Code | Invocation isolation and fake end-to-end run | Not established for the current candidate | Implemented; release verification pending |
+| Hermes Agent | Disabled-tool configuration, trace parsing, Herdr transport, and fake end-to-end run | Not established for the current candidate | Implemented; release verification pending |
+
+The Pi diagnostic proves only that one configured Pi/model/task combination
+completed with valid artifacts. It is not a portability result, does not prove
+the other adapters, and is not retained in the published package.
+
+## Release-verification gate
+
+Promote a harness from “implemented” to “release verified” only after a clean
+smoke using that harness's real executable against the exact immutable candidate:
+
+1. record executable version, exact provider/model id, candidate commit, and
+   skill payload digest;
+2. run one audited paired case with the minimum required tools;
+3. require `artifact_valid`, `mechanism_valid`, and runtime attestation to pass;
+4. retain the manifest, benchmark, raw trace, grading, and redacted setup
+   evidence outside the published skill payload;
+5. record the UTC completion date and evidence location in this matrix.
+
+A failed, blocked, stale, or predecessor-candidate smoke remains visible as
+such; it must not be summarized as current support.

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -134,6 +134,17 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("Setup remediation may interrupt", skill_text)
         self.assertIn("stated fix", skill_text)
 
+    def test_harness_claims_link_the_complete_evidence_matrix(self) -> None:
+        skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        matrix = (SKILL_ROOT / "references" / "harness-support.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("harness evidence matrix", skill_text)
+        self.assertNotIn("Name every supported harness", skill_text)
+        for harness in ("Pi", "Codex", "Claude Code", "Hermes Agent"):
+            self.assertIn(f"| {harness} |", matrix)
+        self.assertIn("release verification pending", matrix)
+
 
 class ModelRecommendationTests(unittest.TestCase):
     def test_provider_name_does_not_inflate_model_tier(self) -> None:


### PR DESCRIPTION
## Summary
- replace the blanket supported-harness claim with an implemented-adapter claim
- add a dated evidence matrix separating deterministic coverage, real-CLI evidence, and release verification
- enforce the matrix link and complete harness inventory in the healthcheck

## Verification
- `bash skills/skill-eval-loop/scripts/healthcheck.sh` (123 tests)
- `python3 -m ruff check skills/skill-eval-loop/tests/test_skill_eval_loop.py`
- `./node_modules/.bin/markdown-link-check README.md` (9 links)
- re-aggregate retained five-case Pi diagnostic: valid, artifact/mechanism/runtime attestation true
- `git diff --check`