### PR TITLE
Default live evaluation pilots to one trial

### DIFF
--- a/skills/skill-eval-loop/SKILL.md
+++ b/skills/skill-eval-loop/SKILL.md
@@ -146,6 +146,11 @@ Pin the identity exactly as the selected harness reports it. Attestation
 normalizes surrounding whitespace and case only: provider-qualified and bare
 model ids are distinct, and no provider or model aliases are inferred.
 
+Skip the recommender discovery command only when the user already supplied an
+exact id confirmed by the current harness inventory or a prior recommender
+result from this setup. A family name such as `sonnet` is not an exact id: run
+discovery or ask the user to choose an exact inventory entry.
+
 Show the budget, balanced, and quality frontier; disclose tier fallbacks and
 unknown cost. For a release claim, prefer the intended deployment model. For
 portability, plan separate runs across tiers. Use no judge when the suite is
@@ -167,15 +172,15 @@ limitations.
 
 ### 5. Choose observation, dry-run the plan, authorize
 
-Name both observation options before constructing the dry run:
+Use `headless` by default. Mention and ask about Herdr only when the user asks
+for observation, a visible UI, or Herdr:
 
 - `headless` (default) — full evidence without a Herdr workspace
 - `herdr` — mirror live transcripts into a retained 2×2 workspace; requires a
   Herdr-managed pane with `HERDR_ENV=1`
 
-Ask unless already selected. Pass `--observer herdr` on dry-run and live only
-when Herdr is chosen, and verify its environment before live trials. Workspace
-path layout lives in
+Pass `--observer herdr` on dry-run and live only when Herdr is explicitly
+chosen, and verify its environment before live trials. Workspace path layout lives in
 [the workspace layout reference](references/workspace-layout.md).
 
 ```bash

--- a/skills/skill-eval-loop/scripts/run_skill_eval.py
+++ b/skills/skill-eval-loop/scripts/run_skill_eval.py
@@ -840,7 +840,7 @@ def main(argv: list[str] | None = None) -> int:
         help="Defaults to .eval-runs/<skill-name>/<run-id>/.",
     )
     parser.add_argument("--model", required=True)
-    parser.add_argument("--trials", type=int, default=3)
+    parser.add_argument("--trials", type=int, default=1)
     parser.add_argument("--harness", required=True, choices=HARNESS_NAMES)
     parser.add_argument("--harness-bin")
     parser.add_argument("--pi-bin")

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -40,6 +40,7 @@ from run_skill_eval import (  # noqa: E402
     _run_condition,
     _validate_references,
     condition_order,
+    main as run_skill_eval_main,
     plan_run,
     run_suite,
 )
@@ -124,6 +125,8 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("Confirm the exact target model", skill_text)
         self.assertIn("explicit yes", remediation)
         self.assertIn("Never ask the user to paste a secret", remediation)
+        self.assertIn("exact id confirmed by the current harness inventory", skill_text)
+        self.assertIn("`sonnet` is not an exact id", skill_text)
 
     def test_interaction_asks_one_question_at_a_time(self) -> None:
         skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
@@ -133,6 +136,8 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("separate turn", skill_text)
         self.assertIn("Setup remediation may interrupt", skill_text)
         self.assertIn("stated fix", skill_text)
+        self.assertIn("Use `headless` by default", skill_text)
+        self.assertNotIn("Name both observation options", skill_text)
 
     def test_harness_claims_link_the_complete_evidence_matrix(self) -> None:
         skill_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
@@ -1863,6 +1868,24 @@ class ProcessControlTests(unittest.TestCase):
 
 
 class PlanningTests(unittest.TestCase):
+    @patch("run_skill_eval.plan_run", return_value={})
+    def test_cli_defaults_to_one_pilot_trial(self, planned) -> None:
+        with patch("builtins.print"):
+            exit_code = run_skill_eval_main(
+                [
+                    "--skill-path",
+                    "fixture-skill",
+                    "--model",
+                    "provider/model-1",
+                    "--harness",
+                    "pi",
+                    "--dry-run",
+                ]
+            )
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(planned.call_args.kwargs["trials"], 1)
+        self.assertEqual(planned.call_args.kwargs["observer"], "headless")
+
     @patch("run_skill_eval.resolve_harness", return_value=("/usr/local/bin/pi", "1.0"))
     def test_default_dry_run_path_is_external_and_not_created(self, _resolve) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary
- align the CLI default with the documented one-trial pilot to avoid accidental 3x spend
- make headless the quiet default and introduce Herdr only for explicit observation/UI requests
- allow model discovery to be skipped only for exact current-inventory ids, not colloquial family names
- freeze trial and observer defaults in a CLI regression test

## Verification
- focused workflow/default tests: 5/5
- evaluator healthcheck: 124/124
- Ruff and `git diff --check` pass

The invocation formula and explicit paid-run authorization gate remain on the always-loaded skill path.