### PR TITLE
Make reparsed traces own model attestation

### DIFF
--- a/skills/skill-eval-loop/scripts/aggregate_benchmark.py
+++ b/skills/skill-eval-loop/scripts/aggregate_benchmark.py
@@ -252,10 +252,6 @@ def _condition_record(
         invalid.append("timeout")
     if record.get("exit_code") != 0:
         invalid.append("runtime_error")
-    if not model_matches(requested_model, record.get("actual_model")):
-        invalid.append("model_mismatch")
-    if record.get("model_attested") is False:
-        invalid.append("model_not_attested")
     judge_records = record.get("judge_records") or []
     if not isinstance(judge_records, list):
         raise ValueError(f"{label}.judge_records must be a list")

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -3797,6 +3797,34 @@ class AggregateTests(unittest.TestCase):
                 any("model_mismatch" in reason for reason in report["invalid_reasons"])
             )
 
+    def test_reparsed_trace_owns_model_attestation_during_aggregation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _make_run(root, [(False, True)])
+            manifest_path = root / "run_manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            control = manifest["trials"][0]["conditions"]["without_skill"]
+            control["model_attested"] = False
+            _write_json(manifest_path, manifest)
+
+            report = aggregate(root)
+            self.assertTrue(report["valid"])
+            self.assertFalse(
+                any(
+                    "model_not_attested" in reason
+                    for reason in report["invalid_reasons"]
+                )
+            )
+
+            control["actual_model"] = "provider/other-model"
+            _write_json(manifest_path, manifest)
+            report = aggregate(root)
+            self.assertFalse(report["valid"])
+            self.assertIn(
+                "case/trial-001/without_skill: manifest_model_mismatch",
+                report["invalid_reasons"],
+            )
+
     def test_aggregation_requires_complete_case_trial_matrix(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)


### PR DESCRIPTION
## Summary
- remove duplicate manifest-boolean/model guards from aggregation
- let the hashed trace parser and runtime-attestation policy own model attestation
- preserve failure when retained `actual_model` disagrees with trace evidence

## Verification
- focused aggregate regressions: 2/2
- evaluator healthcheck: 125/125
- Ruff and `git diff --check` pass