### PR TITLE
Remove unapplied distribution thresholds

### DIFF
--- a/skills/skill-eval-loop/references/eval-suite-schema.md
+++ b/skills/skill-eval-loop/references/eval-suite-schema.md
@@ -19,18 +19,13 @@ each case to retained provenance.
   "activation_mode": "forced",
   "grader_discrimination": "case_contrast",
   "provenance_manifest": "provenance.json",
-  "distribution_policy": {
-    "minimum_pairs": 3,
-    "minimum_effect_size": 0.1,
-    "confidence_level": 0.95
-  },
   "evals": []
 }
 ```
 
-`distribution_policy` remains required by the existing version-3 schema for
-compatibility. The local evaluator records it without making a distribution or
-significance decision.
+Migration: remove the former `distribution_policy` object from version-3
+suites. It was never applied to evaluator decisions, and current validation
+rejects it rather than preserving significance-shaped dead configuration.
 
 Use:
 

--- a/skills/skill-eval-loop/scripts/aggregate_benchmark.py
+++ b/skills/skill-eval-loop/scripts/aggregate_benchmark.py
@@ -935,16 +935,6 @@ def aggregate(run_dir: Path) -> dict:
                 if grader_discrimination == "none"
                 else []
             ),
-            *(
-                [
-                    "distribution_policy was declared by the suite and not applied to this "
-                    f"result: minimum_pairs={declared_policy.get('minimum_pairs')}, "
-                    f"minimum_effect_size={declared_policy.get('minimum_effect_size')}, "
-                    f"confidence_level={declared_policy.get('confidence_level')}."
-                ]
-                if (declared_policy := suite_snapshot.get("distribution_policy"))
-                else []
-            ),
             (
                 f"{harness} skill exposure is configured by the selected adapter; "
                 "runtime attestation and tool-profile precision vary by harness."

--- a/skills/skill-eval-loop/scripts/audit_suite.py
+++ b/skills/skill-eval-loop/scripts/audit_suite.py
@@ -83,7 +83,6 @@ def audit(skill_path: Path, evals_path: Path | None = None) -> dict:
         "case_count": len(suite["evals"]),
         "routing_classes": routing_classes,
         "grader_discrimination": discrimination,
-        "distribution_policy": suite.get("distribution_policy"),
         "provenance_case_count": len(suite.get("provenance_records", {})),
     }
 

--- a/skills/skill-eval-loop/scripts/eval_spec.py
+++ b/skills/skill-eval-loop/scripts/eval_spec.py
@@ -121,37 +121,6 @@ def _sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _validate_distribution_policy(
-    value: object,
-    source: Path,
-) -> dict[str, float | int]:
-    label = f"{source}.distribution_policy"
-    if not isinstance(value, dict):
-        raise ValueError(f"{label} must be an object")
-    minimum_pairs = value.get("minimum_pairs")
-    minimum_effect_size = value.get("minimum_effect_size")
-    confidence_level = value.get("confidence_level")
-    if type(minimum_pairs) is not int or minimum_pairs < 3:
-        raise ValueError(f"{label}.minimum_pairs must be an integer >= 3")
-    if not isinstance(minimum_effect_size, (int, float)) or not (
-        0 < float(minimum_effect_size) <= 1
-    ):
-        raise ValueError(
-            f"{label}.minimum_effect_size must be greater than 0 and at most 1"
-        )
-    if not isinstance(confidence_level, (int, float)) or not (
-        0.8 <= float(confidence_level) < 1
-    ):
-        raise ValueError(
-            f"{label}.confidence_level must be at least 0.8 and below 1"
-        )
-    return {
-        "minimum_pairs": minimum_pairs,
-        "minimum_effect_size": float(minimum_effect_size),
-        "confidence_level": float(confidence_level),
-    }
-
-
 def _load_provenance(
     *,
     suite_root: Path,
@@ -616,18 +585,18 @@ def load_suite(skill_path: Path, evals_path: Path | None = None) -> dict[str, An
             "response-sensitive grader"
         )
     suite_root = source.parent if schema_version == 3 else skill_path
-    distribution_policy = None
     provenance_records: dict[str, Any] = {}
     provenance_sha256 = None
     if schema_version == 3:
+        if "distribution_policy" in data:
+            raise ValueError(
+                f"{source}.distribution_policy is obsolete and must be removed; "
+                "the evaluator never applied these thresholds"
+            )
         case_hashes = {
             str(case["id"]): canonical_sha256(case)
             for case in cases
         }
-        distribution_policy = _validate_distribution_policy(
-            data.get("distribution_policy"),
-            source,
-        )
         provenance_records, provenance_sha256 = _load_provenance(
             suite_root=suite_root,
             value=data.get("provenance_manifest"),
@@ -643,7 +612,6 @@ def load_suite(skill_path: Path, evals_path: Path | None = None) -> dict[str, An
         "grader_discrimination": grader_discrimination,
         "source_path": str(source),
         "suite_root": str(suite_root),
-        "distribution_policy": distribution_policy,
         "provenance_records": provenance_records,
         "provenance_sha256": provenance_sha256,
         "evals": normalized_cases,

--- a/skills/skill-eval-loop/scripts/run_skill_eval.py
+++ b/skills/skill-eval-loop/scripts/run_skill_eval.py
@@ -660,7 +660,6 @@ def run_suite(
             "tool_profile": suite["tool_profile"],
             "activation_mode": suite["activation_mode"],
             "grader_discrimination": suite["grader_discrimination"],
-            "distribution_policy": suite.get("distribution_policy"),
             "source_sha256": _sha256_file(Path(suite["source_path"])),
             "cases": [
                 {

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -605,11 +605,6 @@ def _make_schema3_skill(root: Path, *, tamper: bool = False) -> Path:
         "tool_profile": "no_tools",
         "grader_discrimination": "case_contrast",
         "provenance_manifest": "provenance.json",
-        "distribution_policy": {
-            "minimum_pairs": 3,
-            "minimum_effect_size": 0.1,
-            "confidence_level": 0.95,
-        },
         "evals": [case],
     }
     _write_json(skill / "evals" / "evals.json", suite)
@@ -772,119 +767,26 @@ class SuiteValidationTests(unittest.TestCase):
                 load_suite(skill)
 
 
-class DeclaredPolicyTests(unittest.TestCase):
-    """A declared distribution_policy is recorded and reported as unapplied.
-
-    The schema requires the field and validates its bounds, but no evaluator
-    decision uses it. Saying so in the run artifact keeps it from reading like a
-    threshold the run enforced.
-    """
-
-    def test_limits_name_the_policy_that_did_not_gate_the_result(self) -> None:
+class ObsoletePolicyTests(unittest.TestCase):
+    def test_schema_three_rejects_obsolete_distribution_policy(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            root = Path(temp)
-            _make_run(root, [(True, False), (True, False), (True, True)])
-            snapshot_path = root / "suite_snapshot.json"
-            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
-            snapshot["distribution_policy"] = {
+            skill = _make_schema3_skill(Path(temp))
+            suite_path = skill / "evals" / "evals.json"
+            suite = json.loads(suite_path.read_text(encoding="utf-8"))
+            self.assertNotIn("distribution_policy", suite)
+            suite["distribution_policy"] = {
                 "minimum_pairs": 3,
                 "minimum_effect_size": 0.1,
                 "confidence_level": 0.95,
             }
-            _write_json(snapshot_path, snapshot)
-            manifest_path = root / "run_manifest.json"
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-            manifest["suite_sha256"] = _sha256(snapshot_path)
-            _write_json(manifest_path, manifest)
+            _write_json(suite_path, suite)
 
-            limits = aggregate(root)["limits"]
-            policy_notes = [line for line in limits if "distribution_policy" in line]
-            self.assertEqual(len(policy_notes), 1)
-            self.assertIn("not applied", policy_notes[0])
-            self.assertIn("minimum_effect_size=0.1", policy_notes[0])
-
-    def test_a_run_without_a_declared_policy_gains_no_note(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            root = Path(temp)
-            _make_run(root, [(True, False), (True, False), (True, True)])
-            limits = aggregate(root)["limits"]
-            self.assertFalse([line for line in limits if "distribution_policy" in line])
-
-    def test_run_suite_retains_declared_policy_in_the_snapshot(self) -> None:
-        """Honesty depends on run_suite writing the field, not only aggregate.
-
-        The aggregate-only fixtures above can stay green if the snapshot write is
-        dropped. A schema-3 fake run proves the production path retains the
-        declared policy and names it as unapplied in limits.
-        """
-        with tempfile.TemporaryDirectory() as temp:
-            root = Path(temp)
-            skill = _make_schema3_skill(root)
-            fake_pi = root / "fake-pi"
-            fake_pi.write_text(
-                """#!/usr/bin/env python3
-import json
-import sys
-
-if "--version" in sys.argv:
-    print("fake-pi 1.0")
-    raise SystemExit(0)
-
-treatment = "--skill" in sys.argv
-print(json.dumps({
-    "type": "system",
-    "subtype": "init",
-    "model": "provider/model-1",
-    "session_id": "fixture-session",
-    "skills": ["candidate-skill"] if treatment else [],
-}))
-print(json.dumps({
-    "message": {
-        "role": "assistant",
-        "model": "provider/model-1",
-        "content": [{"type": "text", "text": "done" if treatment else "FAIL"}],
-        "usage": {"input": 1, "output": 1, "totalTokens": 2},
-    }
-}))
-""",
-                encoding="utf-8",
-            )
-            fake_pi.chmod(0o755)
-            output = root / "run"
-            report = run_suite(
-                skill_path=skill,
-                output_dir=output,
-                model="provider/model-1",
-                trials=1,
-                pi_bin=str(fake_pi),
-            )
-            snapshot = json.loads(
-                (output / "suite_snapshot.json").read_text(encoding="utf-8")
-            )
-            self.assertEqual(
-                snapshot["distribution_policy"],
-                {
-                    "minimum_pairs": 3,
-                    "minimum_effect_size": 0.1,
-                    "confidence_level": 0.95,
-                },
-            )
-            self.assertEqual(snapshot["cases"][0]["model_rubric_count"], 0)
-            self.assertEqual(
-                snapshot["cases"][0]["response_sensitive_graders"],
-                [{"name": "Returns done", "type": "response_contains"}],
-            )
-            self.assertTrue(snapshot["cases"][0]["counter_reference_declared"])
-            self.assertEqual(
-                report["grader_discrimination"],
-                {"claim": "case_contrast", "validated": True},
-            )
-            policy_notes = [
-                line for line in report["limits"] if "distribution_policy" in line
-            ]
-            self.assertEqual(len(policy_notes), 1)
-            self.assertIn("not applied", policy_notes[0])
-            self.assertIn("minimum_effect_size=0.1", policy_notes[0])
+            with self.assertRaisesRegex(
+                ValueError,
+                "distribution_policy is obsolete and must be removed",
+            ):
+                load_suite(skill)
+            self.assertEqual(audit(skill)["errors"], ["invalid_legacy_policy"])
 
 
 class CounterReferenceTests(unittest.TestCase):

--- a/skills/skill-scout/evals/evals.json
+++ b/skills/skill-scout/evals/evals.json
@@ -7,11 +7,6 @@
   "activation_mode": "forced",
   "grader_discrimination": "case_contrast",
   "provenance_manifest": "provenance.json",
-  "distribution_policy": {
-    "minimum_pairs": 3,
-    "minimum_effect_size": 0.1,
-    "confidence_level": 0.95
-  },
   "evals": [
     {
       "id": "local-fit-beats-reputation",

--- a/skills/skill-scout/evals/provenance.json
+++ b/skills/skill-scout/evals/provenance.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "suite_sha256": "9cfbdbf5ddcbad3851d867fc9df704569ba88bcd6b2993a8c82c22975acf9faf",
+  "suite_sha256": "6788fd125d644d9cb1e13ec14ade96cc43f3fab722c7e9431beceaf5aa6bf3ff",
   "cases": [
     {
       "case_id": "local-fit-beats-reputation",

--- a/skills/triangulate-me/evals/evals.json
+++ b/skills/triangulate-me/evals/evals.json
@@ -7,11 +7,6 @@
   "activation_mode": "forced",
   "grader_discrimination": "case_contrast",
   "provenance_manifest": "provenance.json",
-  "distribution_policy": {
-    "minimum_pairs": 3,
-    "minimum_effect_size": 0.2,
-    "confidence_level": 0.95
-  },
   "evals": [
     {
       "id": "separates-need-from-proposed-feature",

--- a/skills/triangulate-me/evals/provenance.json
+++ b/skills/triangulate-me/evals/provenance.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "suite_sha256": "8931e2d33e8a31f21b75f462cb6872033a87104963a2686dc9776b7852533d0f",
+  "suite_sha256": "6f51f705c082da5b516c6ab42aaeff0f98f27290e4d8b2dba5c3cf3d7dcfbad7",
   "cases": [
     {"case_id": "separates-need-from-proposed-feature", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-separates-need-from-proposed-feature", "source_type": "author_scenario", "observed_at": "2026-08-08", "task_author": "Codex with user authorization", "artifact": "provenance/separates-need-from-proposed-feature.json", "artifact_sha256": "444669221147891a099c501a9929b7a15c5d087cd821fe8c2c574a7ffe00527f", "case_sha256": "afa11b4182b1c37b04df2c37ca3ec20e0393f48e75edf307380a42cd263a4fdc"},
     {"case_id": "abstains-pending-database-evidence", "origin": "author_derived", "source_id": "triangulate-me-author-scenario-abstains-pending-database-evidence", "source_type": "author_scenario", "observed_at": "2026-08-08", "task_author": "Codex with user authorization", "artifact": "provenance/abstains-pending-database-evidence.json", "artifact_sha256": "d53ba205f1876388e31088ed12fd8710ce9bedde8b081847989007ea4b1172bb", "case_sha256": "664af55428e73233ab9bd7865dbdc04f8ae565abf73cb2fc82d0a9ed1259d573"},


### PR DESCRIPTION
## Summary
- hard-delete the required-but-unapplied `distribution_policy` field from schema-3 suites
- reject old suites with an actionable migration message instead of allowing two valid schema classes
- remove persistence, aggregation prose, and 181 lines of dead validation/test machinery
- refresh published suite provenance hashes

## Verification
- Skill Scout audit: valid, 9/9 contrast and provenance cases
- Triangulate audit: valid, 15/15 contrast and provenance cases
- obsolete-field refusal regression passes with `invalid_legacy_policy`
- repository tests: 50/50
- evaluator healthcheck: 123/123
- Ruff and `git diff --check` pass

This intentionally chooses the hard-delete resolution from #10 and supersedes the wrapper proposal in #22.