### PR TITLE
Unify target and judge runtime attestation

### DIFF
--- a/skills/skill-eval-loop/references/interpret-benchmark.md
+++ b/skills/skill-eval-loop/references/interpret-benchmark.md
@@ -10,7 +10,9 @@ run. Report only local paired evidence.
   used the suite's activation mode, and kept the control unexposed.
 - `runtime_attestation_complete` — whether the trace independently names skill
   injection or explicit skill access. Some harness traces omit this lower-layer
-  event.
+  event. Forced Codex treatment also requires explicit skill access while the
+  run is being written; re-aggregation does not retroactively impose that
+  write-time-only check.
 - `outcome_verdict` — `improved`, `regressed`, or `no_difference`.
 - `verdict` — top-level result; becomes `invalid` or `mechanism_unconfirmed`
   when those boundaries fail.
@@ -45,6 +47,11 @@ do not infer zero usage from that missing historical metadata.
 
 Treat assigned intervention, runtime attestation, routing decision, and task
 outcome as separate evidence layers.
+
+Always report those layers separately: artifact validity, mechanism validity,
+runtime attestation, outcome, autonomous selection when measured, usage with
+coverage, and the unproven list. `mechanism_unconfirmed` means attribution is
+unproven; it does not mean the skill failed to improve the observed outcome.
 
 Leave unproven: causal attribution, statistical significance, distribution
 readiness, security approval, and blind-review independence. Condition order is

--- a/skills/skill-eval-loop/scripts/model_grader.py
+++ b/skills/skill-eval-loop/scripts/model_grader.py
@@ -9,7 +9,8 @@ import re
 from pathlib import Path
 from typing import Any
 
-from runtime_adapters import build_judge_invocation, model_matches, trace_metadata
+from runtime_adapters import build_judge_invocation, trace_metadata
+from runtime_attestation import require_judge_runtime_attestation
 from process_control import run_captured
 
 
@@ -119,19 +120,12 @@ rubric requirement. Return JSON only:
             else None
         ),
     )
-    if harness == "codex" and not metadata.get("attestation_trace_path"):
-        raise RuntimeError(
-            f"judge model {model} was not attested; persisted Codex rollout "
-            f"is missing; see {trace_path}"
-        )
-    if metadata.get("model_attested") is not True:
-        raise RuntimeError(f"judge model {model} was not attested; see {trace_path}")
-    actual_model = metadata.get("actual_model")
-    if not model_matches(model, actual_model):
-        raise RuntimeError(
-            f"requested judge model {model} but attested {actual_model}; "
-            f"see {trace_path}"
-        )
+    require_judge_runtime_attestation(
+        metadata,
+        harness=harness,
+        requested_model=model,
+        trace_path=trace_path,
+    )
     attestation_trace = metadata.get("attestation_trace_path")
     grade = _parse_grade(str(metadata.get("final_response", "")))
     evidence = {

--- a/skills/skill-eval-loop/scripts/runtime_attestation.py
+++ b/skills/skill-eval-loop/scripts/runtime_attestation.py
@@ -33,6 +33,30 @@ def evaluate_target_trace_attestation(
     Forced-skill access is checked only when ``condition`` and
     ``activation_mode`` identify a Codex forced treatment (write-time).
     """
+    reasons = evaluate_model_trace_attestation(
+        metadata,
+        harness=harness,
+        requested_model=requested_model,
+        recorded_actual_model=recorded_actual_model,
+    )
+    if (
+        harness == "codex"
+        and condition == "with_skill"
+        and activation_mode == "forced"
+        and metadata.get("skill_explicitly_accessed") is not True
+    ):
+        reasons.append("forced_skill_not_accessed")
+    return reasons
+
+
+def evaluate_model_trace_attestation(
+    metadata: Mapping[str, Any],
+    *,
+    harness: str,
+    requested_model: str,
+    recorded_actual_model: object | None = None,
+) -> list[str]:
+    """Return shared model-identity reason codes for targets and judges."""
     reasons: list[str] = []
     if harness == "codex" and not metadata.get("attestation_trace_path"):
         reasons.append("attestation_trace_missing")
@@ -46,13 +70,6 @@ def evaluate_target_trace_attestation(
         attested_model,
     ):
         reasons.append("manifest_model_mismatch")
-    if (
-        harness == "codex"
-        and condition == "with_skill"
-        and activation_mode == "forced"
-        and metadata.get("skill_explicitly_accessed") is not True
-    ):
-        reasons.append("forced_skill_not_accessed")
     return reasons
 
 
@@ -66,7 +83,11 @@ def require_target_runtime_attestation(
     skill_name: str,
     trace_path: Path,
 ) -> None:
-    """Raise ``RuntimeError`` when write-time target attestation fails."""
+    """Raise for the first write-time target failure in evaluation order.
+
+    Forced-skill access is write-time only. Aggregate callers must omit
+    ``condition`` and ``activation_mode`` when re-evaluating retained traces.
+    """
     reasons = evaluate_target_trace_attestation(
         metadata,
         harness=harness,
@@ -85,6 +106,40 @@ def require_target_runtime_attestation(
             trace_path=trace_path,
         )
     )
+
+
+def require_judge_runtime_attestation(
+    metadata: Mapping[str, Any],
+    *,
+    harness: str,
+    requested_model: str,
+    trace_path: Path,
+) -> None:
+    """Raise for the first write-time judge failure in evaluation order."""
+    reasons = evaluate_model_trace_attestation(
+        metadata,
+        harness=harness,
+        requested_model=requested_model,
+    )
+    if not reasons:
+        return
+    reason = reasons[0]
+    actual_model = metadata.get("actual_model")
+    if reason == "attestation_trace_missing":
+        message = (
+            f"judge model {requested_model} was not attested; persisted Codex "
+            f"rollout is missing; see {trace_path}"
+        )
+    elif reason == "model_not_attested":
+        message = f"judge model {requested_model} was not attested; see {trace_path}"
+    elif reason == "model_mismatch":
+        message = (
+            f"requested judge model {requested_model} but attested {actual_model}; "
+            f"see {trace_path}"
+        )
+    else:
+        raise ValueError(f"unhandled judge attestation reason: {reason}")
+    raise RuntimeError(message)
 
 
 def _write_time_message(

--- a/skills/skill-eval-loop/tests/test_skill_eval_loop.py
+++ b/skills/skill-eval-loop/tests/test_skill_eval_loop.py
@@ -54,7 +54,9 @@ from runtime_adapters import (  # noqa: E402
     validate_pinned_model,
 )
 from runtime_attestation import (  # noqa: E402
+    evaluate_model_trace_attestation,
     evaluate_target_trace_attestation,
+    require_judge_runtime_attestation,
     require_target_runtime_attestation,
 )
 from workspace_paths import DEFAULT_EVAL_RUNS_ROOT, default_run_output  # noqa: E402
@@ -1029,6 +1031,64 @@ class TargetAttestationOwnerTests(unittest.TestCase):
         )
         self.assertIn("attestation_trace_missing", reasons)
         self.assertIn("model_not_attested", reasons)
+
+    def test_target_and_judge_share_model_reason_order(self) -> None:
+        metadata = self._ok_metadata(
+            attestation_trace_path=None,
+            model_attested=False,
+            actual_model="provider/other",
+        )
+        shared = evaluate_model_trace_attestation(
+            metadata,
+            harness="codex",
+            requested_model="provider/model-1",
+        )
+        target = evaluate_target_trace_attestation(
+            metadata,
+            harness="codex",
+            requested_model="provider/model-1",
+        )
+        self.assertEqual(
+            shared,
+            ["attestation_trace_missing", "model_not_attested", "model_mismatch"],
+        )
+        self.assertEqual(target, shared)
+
+    def test_require_uses_the_first_shared_failure_for_target_and_judge(self) -> None:
+        metadata = self._ok_metadata(
+            attestation_trace_path=None,
+            model_attested=False,
+            actual_model="provider/other",
+        )
+        with self.assertRaisesRegex(RuntimeError, "persisted Codex rollout is missing"):
+            require_target_runtime_attestation(
+                metadata,
+                harness="codex",
+                requested_model="provider/model-1",
+                condition="without_skill",
+                activation_mode="forced",
+                skill_name="fixture-skill",
+                trace_path=Path("/tmp/trace.jsonl"),
+            )
+        with self.assertRaisesRegex(RuntimeError, "persisted Codex rollout is missing"):
+            require_judge_runtime_attestation(
+                metadata,
+                harness="codex",
+                requested_model="provider/model-1",
+                trace_path=Path("/tmp/trace.jsonl"),
+            )
+
+    def test_judge_uses_shared_model_mismatch_policy(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "requested judge model provider/model-1 but attested provider/other",
+        ):
+            require_judge_runtime_attestation(
+                self._ok_metadata(actual_model="provider/other"),
+                harness="codex",
+                requested_model="provider/model-1",
+                trace_path=Path("/tmp/trace.jsonl"),
+            )
 
     def test_evaluate_reports_manifest_model_mismatch(self) -> None:
         reasons = evaluate_target_trace_attestation(
@@ -3590,6 +3650,28 @@ class AggregateTests(unittest.TestCase):
             self.assertFalse(report["runtime_attestation_complete"])
             self.assertEqual(report["outcome_verdict"], "improved")
             self.assertEqual(report["verdict"], "improved")
+
+    def test_forced_skill_access_remains_a_write_time_only_check(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _make_run(root, [(False, True)])
+            manifest_path = root / "run_manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["harness"] = "codex"
+            for condition in ("without_skill", "with_skill"):
+                record = manifest["trials"][0]["conditions"][condition]
+                record["attestation_trace_path"] = record["trace_path"]
+                record["attestation_trace_sha256"] = record["trace_sha256"]
+            _write_json(manifest_path, manifest)
+
+            report = aggregate(root)
+            self.assertTrue(report["artifact_valid"])
+            self.assertFalse(
+                any(
+                    "forced_skill_not_accessed" in reason
+                    for reason in report["invalid_reasons"]
+                )
+            )
 
     def test_trace_visible_control_use_blocks_mechanism_claim(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary
- share one ordered model-attestation reason-code policy between target and judge calls
- preserve role-specific actionable error messages
- document and test first-failure precedence
- lock forced Codex skill access as a write-time-only check
- require reports to relay evidence layers separately and clarify `mechanism_unconfirmed`

## Verification
- focused attestation tests: 13/13
- evaluator healthcheck: 127/127
- Ruff and `git diff --check` pass

Closes #20, #23, #24, and completes the report-shape acceptance in #8.